### PR TITLE
Aliases support

### DIFF
--- a/ext/panko_serializer/attributes_iterator.h
+++ b/ext/panko_serializer/attributes_iterator.h
@@ -11,6 +11,7 @@ typedef void (*EachAttributeFunc)(VALUE object,
 
 extern VALUE panko_each_attribute(VALUE object,
                                   VALUE attributes,
+                                  VALUE aliases,
                                   EachAttributeFunc func,
                                   VALUE context);
 

--- a/ext/panko_serializer/panko_serializer.c
+++ b/ext/panko_serializer/panko_serializer.c
@@ -48,16 +48,16 @@ void panko_attributes_iter(VALUE object,
                            VALUE name,
                            VALUE value,
                            VALUE type_metadata,
-                           VALUE context) {
-  write_value(context, name, value, type_metadata);
+                           VALUE str_writer) {
+  write_value(str_writer, name, value, type_metadata);
 }
 
 void serialize_fields(VALUE subject,
                       VALUE str_writer,
                       SerializationDescriptor descriptor,
                       VALUE context) {
-  panko_each_attribute(subject, descriptor->fields, panko_attributes_iter,
-                       str_writer);
+  panko_each_attribute(subject, descriptor->fields, descriptor->aliases,
+                       panko_attributes_iter, str_writer);
 
   serialize_method_fields(subject, str_writer, descriptor, context);
 }

--- a/ext/panko_serializer/serialization_descriptor.c
+++ b/ext/panko_serializer/serialization_descriptor.c
@@ -18,6 +18,7 @@ static void serialization_descriptor_free(void* ptr) {
   sd->method_fields = Qnil;
   sd->has_one_associations = Qnil;
   sd->has_many_associations = Qnil;
+  sd->aliases = Qnil;
 }
 
 void serialization_descriptor_mark(SerializationDescriptor data) {
@@ -27,6 +28,7 @@ void serialization_descriptor_mark(SerializationDescriptor data) {
   rb_gc_mark(data->method_fields);
   rb_gc_mark(data->has_one_associations);
   rb_gc_mark(data->has_many_associations);
+  rb_gc_mark(data->aliases);
 }
 
 static VALUE serialization_descriptor_new(int argc, VALUE* argv, VALUE self) {
@@ -38,6 +40,7 @@ static VALUE serialization_descriptor_new(int argc, VALUE* argv, VALUE self) {
   sd->method_fields = Qnil;
   sd->has_one_associations = Qnil;
   sd->has_many_associations = Qnil;
+  sd->aliases = Qnil;
 
   return Data_Wrap_Struct(cSerializationDescriptor,
                           serialization_descriptor_mark,
@@ -126,6 +129,17 @@ VALUE serialization_descriptor_type_aref(VALUE self, VALUE type) {
   return sd->serializer_type;
 }
 
+VALUE serialization_descriptor_aliases_set(VALUE self, VALUE aliases) {
+  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  sd->aliases = aliases;
+  return Qnil;
+}
+
+VALUE serialization_descriptor_aliases_aref(VALUE self, VALUE aliases) {
+  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  return sd->aliases;
+}
+
 // Exposing this for testing
 VALUE serialization_descriptor_build_serializer(VALUE self) {
   SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
@@ -165,8 +179,13 @@ void panko_init_serialization_descriptor(VALUE mPanko) {
 
   rb_define_method(cSerializationDescriptor,
                    "type=", serialization_descriptor_type_set, 1);
+  rb_define_method(cSerializationDescriptor, "type",
+                   serialization_descriptor_type_aref, 0);
+
   rb_define_method(cSerializationDescriptor,
-                   "type", serialization_descriptor_type_aref, 0);
+                   "aliases=", serialization_descriptor_aliases_set, 1);
+  rb_define_method(cSerializationDescriptor, "aliases",
+                   serialization_descriptor_aliases_aref, 0);
 
   rb_define_method(cSerializationDescriptor, "build_serializer",
                    serialization_descriptor_build_serializer, 0);

--- a/ext/panko_serializer/serialization_descriptor.h
+++ b/ext/panko_serializer/serialization_descriptor.h
@@ -12,6 +12,7 @@ typedef struct _SerializationDescriptor {
   // Metadata
   VALUE fields;
   VALUE method_fields;
+  VALUE aliases;
   VALUE has_one_associations;
   VALUE has_many_associations;
 } * SerializationDescriptor;

--- a/lib/panko/serialization_descriptor.rb
+++ b/lib/panko/serialization_descriptor.rb
@@ -108,10 +108,5 @@ module Panko
 
       fields
     end
-
-
-    def self.resolve_serializer(serializer)
-      Object.const_get(serializer.name)
-    end
   end
 end

--- a/lib/panko/serialization_descriptor.rb
+++ b/lib/panko/serialization_descriptor.rb
@@ -26,6 +26,8 @@ module Panko
       backend.has_many_associations = descriptor.has_many_associations
       backend.has_one_associations = descriptor.has_one_associations
 
+      backend.aliases = descriptor.aliases
+
       backend
     end
 

--- a/lib/panko/serializer.rb
+++ b/lib/panko/serializer.rb
@@ -9,6 +9,7 @@ module Panko
         base._descriptor = Panko::SerializationDescriptor.new
         base._descriptor.type = base
 
+        base._descriptor.aliases = {}
         base._descriptor.fields = []
         base._descriptor.method_fields = []
         base._descriptor.has_many_associations = []
@@ -19,6 +20,11 @@ module Panko
 
       def attributes(*attrs)
         @_descriptor.fields.push(*attrs).uniq!
+      end
+
+      def aliases(aliases = {})
+        @_descriptor.aliases = aliases
+        attributes(*aliases.keys)
       end
 
       def method_added(method)

--- a/lib/panko/serializer.rb
+++ b/lib/panko/serializer.rb
@@ -28,7 +28,7 @@ module Panko
       end
 
       def has_one(name, options)
-        serializer_const = Panko::SerializationDescriptor.resolve_serializer(options[:serializer])
+        serializer_const = options[:serializer]
 
         @_descriptor.has_one_associations << [
           name,
@@ -37,8 +37,7 @@ module Panko
       end
 
       def has_many(name, options)
-        serializer_name = options[:serializer] || options[:each_serializer]
-        serializer_const = Panko::SerializationDescriptor.resolve_serializer(serializer_name)
+        serializer_const = options[:serializer] || options[:each_serializer]
 
         @_descriptor.has_many_associations << [
           name,

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -85,6 +85,22 @@ describe Panko::Serializer do
 
       expect(output).to eq("value" => [1, 2, 3])
     end
+
+    it "allows to alias attributes" do
+      class FooWithAliasesSerializer < Panko::Serializer
+        attributes :address
+
+        aliases name: :full_name
+      end
+
+      serializer = FooWithAliasesSerializer.new
+
+      foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
+      output = serializer.serialize foo
+
+      expect(output).to eq("full_name" => foo.name,
+                           "address" => foo.address)
+    end
   end
 
   context "context" do


### PR DESCRIPTION
When serializers implement alias with method attributes, it get direct hit
on performance (becuase all type casting don't go through panko).

Aliases, allow to supply alias to attributes, for example:
```ruby
class FooWithAliasesSerializer < Panko::Serializer
 attributes :address

 aliases name: :full_name end
end
```