### PR TITLE
Rails 5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/bundle/
 
 # rspec failure tracking
 .rspec_status

--- a/benchmarks/type_casts/bm_panko.rb
+++ b/benchmarks/type_casts/bm_panko.rb
@@ -44,6 +44,9 @@ def db_panko_time
 		Panko::_type_cast(converter, from)
   end
 end
+panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Json, '{"a":1}', {a:1}
+db_panko_time
+utc_panko_time
 
 panko_type_convert ActiveRecord::Type::String, 1, "1"
 panko_type_convert ActiveRecord::Type::Text, 1, "1"
@@ -53,9 +56,11 @@ panko_type_convert ActiveRecord::Type::Float, "Infinity", ::Float::INFINITY
 panko_type_convert ActiveRecord::Type::Boolean, "true", true
 panko_type_convert ActiveRecord::Type::Boolean, "t", true
 
-panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer, "1", 1
-panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Float, "1.23", 1.23
-panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Float, "Infinity", ::Float::INFINITY
+if ENV["RAILS_VERSION"].start_with? "4.2"
+  panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer, "1", 1
+  panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Float, "1.23", 1.23
+  panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Float, "Infinity", ::Float::INFINITY
+end
 
 panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Json, '{"a":1}', {a:1}
 db_panko_time

--- a/spec/type_cast_spec.rb
+++ b/spec/type_cast_spec.rb
@@ -50,7 +50,7 @@ describe "Type Casting" do
       it { expect(Panko._type_cast(type, six: 6)).to be_nil }
     end
 
-    context "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer" do
+    context "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer", if: ENV["RAILS_VERSION"].start_with?("4.2") do
       let(:type) { ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer.new }
 
       it { expect(Panko._type_cast(type, "")).to be_nil }


### PR DESCRIPTION
### Changes

- Adapting attributes reading to @attributes being a hash a not a LazyAttributeHash
- Typecasting: use `deserialize` if available, otherwise `type_cast_from_database` 

### Benchmarks

Rails 5.1
```
{"label":"Panko_SimpleWithMethodCall_Posts_2300","ips":"74.41","allocs":"4908/15"}
{"label":"Panko_SimpleWithMethodCall_Posts_50","ips":"4,164.64","allocs":"117/0"}
{"label":"Panko_HasOne_Posts_2300","ips":"45.66","allocs":"9216/0"}
{"label":"Panko_HasOne_Posts_50","ips":"3,083.36","allocs":"216/0"}
{"label":"Panko_Simple_Posts_2300","ips":"89.07","allocs":"4614/0"}
{"label":"Panko_Simple_Posts_50","ips":"5,517.12","allocs":"114/0"}
```

Rails 4.2
```
{"label":"Panko_SimpleWithMethodCall_Posts_2300","ips":"90.02","allocs":"4957/15"}
{"label":"Panko_SimpleWithMethodCall_Posts_50","ips":"4,613.35","allocs":"117/0"}
{"label":"Panko_HasOne_Posts_2300","ips":"50.62","allocs":"9216/0"}
{"label":"Panko_HasOne_Posts_50","ips":"3,249.34","allocs":"216/0"}
{"label":"Panko_Simple_Posts_2300","ips":"95.68","allocs":"4614/0"}
{"label":"Panko_Simple_Posts_50","ips":"5,451.29","allocs":"114/0"}
```