### PR TITLE
Large refactor and performance improvements

### DIFF
--- a/ext/panko_serializer/association.c
+++ b/ext/panko_serializer/association.c
@@ -1,0 +1,69 @@
+#include "association.h"
+
+VALUE cAssociation;
+
+static void association_free(void* ptr) {
+  if (!ptr) {
+    return;
+  }
+
+  Association association = (Association)ptr;
+  association->name_str = Qnil;
+  association->name_id = Qnil;
+  association->name_sym = Qnil;
+  association->rb_descriptor = Qnil;
+
+  if (!association->descriptor || association->descriptor != NULL) {
+    association->descriptor = NULL;
+  }
+
+  xfree(association);
+}
+
+void association_mark(Association data) {
+  rb_gc_mark(data->name_str);
+  rb_gc_mark(data->name_id);
+  rb_gc_mark(data->name_sym);
+  rb_gc_mark(data->rb_descriptor);
+
+  if (data->descriptor != NULL) {
+    sd_mark(data->descriptor);
+  }
+}
+
+static VALUE association_new(int argc, VALUE* argv, VALUE self) {
+  Association association = ALLOC(struct _Association);
+
+  association->name_sym = argv[0];
+  association->name_str = argv[1];
+  association->rb_descriptor = argv[2];
+
+  association->name_id = rb_sym2id(association->name_sym);
+  association->descriptor = sd_read(association->rb_descriptor);
+
+  return Data_Wrap_Struct(cAssociation, association_mark, association_free,
+                          association);
+}
+
+Association association_read(VALUE association) {
+  return (Association)DATA_PTR(association);
+}
+
+VALUE association_first_ref(VALUE self) {
+  Association association = (Association)DATA_PTR(self);
+  return association->name_sym;
+}
+
+VALUE association_last_ref(VALUE self) {
+  Association association = (Association)DATA_PTR(self);
+  return association->rb_descriptor;
+}
+
+void panko_init_association(VALUE mPanko) {
+  cAssociation = rb_define_class_under(mPanko, "Association", rb_cObject);
+
+  rb_define_module_function(cAssociation, "new", association_new, -1);
+
+  rb_define_method(cAssociation, "first", association_first_ref, 0);
+  rb_define_method(cAssociation, "last", association_last_ref, 0);
+}

--- a/ext/panko_serializer/association.h
+++ b/ext/panko_serializer/association.h
@@ -1,0 +1,20 @@
+#include <ruby.h>
+
+#ifndef __ASSOCIATION_H__
+#define __ASSOCIATION_H__
+
+#include "serialization_descriptor.h"
+
+typedef struct _Association {
+  VALUE name_id;
+  VALUE name_sym;
+  VALUE name_str;
+
+  VALUE rb_descriptor;
+  SerializationDescriptor descriptor;
+} * Association;
+
+Association association_read(VALUE association);
+void panko_init_associaiton(VALUE mPanko);
+
+#endif

--- a/ext/panko_serializer/attribute.c
+++ b/ext/panko_serializer/attribute.c
@@ -1,0 +1,65 @@
+#include "attribute.h"
+
+VALUE cAttribute;
+
+static void attribute_free(void* ptr) {
+  if (!ptr) {
+    return;
+  }
+
+  Attribute attribute = (Attribute)ptr;
+  attribute->name_str = Qnil;
+  attribute->alias_name = Qnil;
+  attribute->type = Qnil;
+  attribute->record_class = Qnil;
+
+  xfree(attribute);
+}
+
+void attribute_mark(Attribute data) {
+  rb_gc_mark(data->name_str);
+  rb_gc_mark(data->alias_name);
+  rb_gc_mark(data->type);
+  rb_gc_mark(data->record_class);
+}
+
+static VALUE attribute_new(int argc, VALUE* argv, VALUE self) {
+  Attribute attribute = ALLOC(struct _Attribute);
+
+  attribute->name_str = argv[0];
+  attribute->alias_name = argv[1];
+  attribute->type = Qnil;
+  attribute->record_class = Qnil;
+
+  return Data_Wrap_Struct(cAttribute, attribute_mark, attribute_free,
+                          attribute);
+}
+
+Attribute attribute_read(VALUE attribute) {
+  return (Attribute)DATA_PTR(attribute);
+}
+
+void attribute_try_invalidate(Attribute attribute, VALUE new_record_class) {
+  if (rb_equal(attribute->record_class, new_record_class) == Qfalse) {
+    attribute->type = Qnil;
+    attribute->record_class = new_record_class;
+  }
+}
+
+VALUE attribute_name_ref(VALUE self) {
+  Attribute attribute = (Attribute)DATA_PTR(self);
+  return attribute->name_str;
+}
+
+VALUE attribute_alias_name_ref(VALUE self) {
+  Attribute attribute = (Attribute)DATA_PTR(self);
+  return attribute->alias_name;
+}
+void panko_init_attribute(VALUE mPanko) {
+  cAttribute = rb_define_class_under(mPanko, "Attribute", rb_cObject);
+
+  rb_define_module_function(cAttribute, "new", attribute_new, -1);
+
+  rb_define_method(cAttribute, "name", attribute_name_ref, 0);
+  rb_define_method(cAttribute, "alias_name", attribute_alias_name_ref, 0);
+}

--- a/ext/panko_serializer/attribute.h
+++ b/ext/panko_serializer/attribute.h
@@ -1,0 +1,22 @@
+#include <ruby.h>
+
+#ifndef __ATTRIBUTE_H__
+#define __ATTRIBUTE_H__
+
+typedef struct _Attribute {
+  VALUE name_str;
+  VALUE alias_name;
+
+  /*
+   * We will cache the activerecord type
+   * by the record_class
+   */
+  VALUE type;
+  VALUE record_class;
+} * Attribute;
+
+Attribute attribute_read(VALUE attribute);
+void attribute_try_invalidate(Attribute attribute, VALUE record);
+void panko_init_attribute(VALUE mPanko);
+
+#endif

--- a/ext/panko_serializer/attributes_iterator.c
+++ b/ext/panko_serializer/attributes_iterator.c
@@ -49,79 +49,124 @@ void read_attribute_from_hash(VALUE attributes_hash,
   volatile VALUE attribute_metadata = rb_hash_aref(attributes_hash, member);
   if (attribute_metadata != Qnil) {
     *value = rb_ivar_get(attribute_metadata, value_before_type_cast_id);
-    *type = rb_ivar_get(attribute_metadata, type_id);
+
+    if (*type == Qnil) {
+      *type = rb_ivar_get(attribute_metadata, type_id);
+      if (*type != Qnil) {
+        *type = CLASS_OF(*type);
+      }
+    }
   }
+}
+
+struct attributes {
+  VALUE attributes_hash;
+
+  VALUE types;
+  VALUE additional_types;
+  VALUE values;
+
+  // heuristicts
+  bool shouldReadFromHash;
+  bool tryToReadFromAdditionalTypes;
+};
+
+struct attributes init_context(VALUE obj) {
+  struct attributes attributes_ctx;
+  attributes_ctx.attributes_hash = Qnil;
+  attributes_ctx.values = Qnil;
+  attributes_ctx.types = Qnil;
+  attributes_ctx.additional_types = Qnil;
+
+  attributes_ctx.shouldReadFromHash = false;
+  attributes_ctx.tryToReadFromAdditionalTypes = false;
+
+  volatile VALUE lazy_attribute_hash = panko_read_lazy_attributes_hash(obj);
+
+  if (lazy_attribute_hash == Qnil) {
+    // TODO: handle
+  }
+
+  if (RB_TYPE_P(lazy_attribute_hash, T_HASH)) {
+    attributes_ctx.attributes_hash = lazy_attribute_hash;
+    attributes_ctx.shouldReadFromHash = true;
+  } else {
+    volatile VALUE delegate_hash =
+        rb_ivar_get(lazy_attribute_hash, delegate_hash_id);
+    if (!panko_is_empty_hash(delegate_hash)) {
+      attributes_ctx.attributes_hash = delegate_hash;
+      attributes_ctx.shouldReadFromHash = true;
+    }
+
+    panko_read_types_and_value(lazy_attribute_hash, &attributes_ctx.types,
+                               &attributes_ctx.additional_types,
+                               &attributes_ctx.values);
+
+    attributes_ctx.tryToReadFromAdditionalTypes =
+        !panko_is_empty_hash(attributes_ctx.additional_types);
+  }
+
+  return attributes_ctx;
+}
+
+VALUE read_attribute(struct attributes attributes_ctx, Attribute attribute) {
+  VALUE member = attribute->name_str;
+  volatile VALUE value = Qundef;
+
+  if (attributes_ctx.values != Qnil && value == Qundef) {
+    value = rb_hash_aref(attributes_ctx.values, member);
+    if (value == Qnil) {
+      value = Qundef;
+    }
+  }
+
+  if (value == Qundef && attributes_ctx.shouldReadFromHash) {
+    read_attribute_from_hash(attributes_ctx.attributes_hash, member, &value,
+                             &attribute->type);
+  }
+
+  if (attribute->type == Qnil) {
+    if (attributes_ctx.tryToReadFromAdditionalTypes) {
+      attribute->type = rb_hash_aref(attributes_ctx.additional_types, member);
+    }
+
+    if (attributes_ctx.types != Qnil && attribute->type == Qnil) {
+      attribute->type = rb_hash_aref(attributes_ctx.types, member);
+    }
+
+    if (attribute->type != Qnil) {
+      attribute->type = CLASS_OF(attribute->type);
+    }
+  }
+
+  if (attribute->type != Qnil && value != Qnil) {
+    return type_cast(attribute->type, value);
+  }
+
+  return value;
 }
 
 VALUE panko_each_attribute(VALUE obj,
                            VALUE attributes,
-                           VALUE aliases,
                            EachAttributeFunc func,
                            VALUE context) {
-  volatile VALUE lazy_attribute_hash, delegate_hash;
-  VALUE values = Qundef;
-  VALUE types = Qundef;
-  VALUE additional_types = Qundef;
-  int i;
-
-  lazy_attribute_hash = panko_read_lazy_attributes_hash(obj);
-  if (lazy_attribute_hash == Qnil) {
-    return Qnil;
-  }
-
-  bool tryToReadFromDelegateHash = false;
-  bool tryToReadFromAdditionalTypes = false;
-
-  // If lazy_attribute_hash is not ActiveRecord::LazyAttributeHash
-  // and it's actually hash, read from it
-  if (RB_TYPE_P(lazy_attribute_hash, T_HASH)) {
-    delegate_hash = lazy_attribute_hash;
-    tryToReadFromDelegateHash = true;
-  } else {
-    delegate_hash = rb_ivar_get(lazy_attribute_hash, delegate_hash_id);
-    tryToReadFromDelegateHash = !panko_is_empty_hash(delegate_hash);
-
-    panko_read_types_and_value(lazy_attribute_hash, &types, &additional_types,
-                               &values);
-
-    tryToReadFromAdditionalTypes = !panko_is_empty_hash(additional_types);
-  }
-
-  bool tryToReadFromAliases = !panko_is_empty_hash(aliases);
+  long i;
+  struct attributes attributes_ctx = init_context(obj);
+  volatile VALUE record_class = CLASS_OF(obj);
 
   for (i = 0; i < RARRAY_LEN(attributes); i++) {
-    volatile VALUE member_raw = RARRAY_AREF(attributes, i);
-    volatile VALUE member = rb_sym2str(member_raw);
+    volatile VALUE raw_attribute = RARRAY_AREF(attributes, i);
+    Attribute attribute = attribute_read(raw_attribute);
+    attribute_try_invalidate(attribute, record_class);
 
-    volatile VALUE value = Qundef;
-    volatile VALUE type_metadata = Qnil;
-
-    // First try to read from delegate hash,
-    // If the object was create in memory `User.new(name: "Yosi")`
-    // it won't exist in types/values
-    if (tryToReadFromDelegateHash) {
-      read_attribute_from_hash(delegate_hash, member, &value, &type_metadata);
+    VALUE name_str = attribute->name_str;
+    if (attribute->alias_name != Qnil) {
+      name_str = attribute->alias_name;
     }
 
-    if (values != Qundef && value == Qundef) {
-      value = rb_hash_aref(values, member);
+    VALUE value = read_attribute(attributes_ctx, attribute);
 
-      if (tryToReadFromAdditionalTypes) {
-        type_metadata = rb_hash_aref(additional_types, member);
-      }
-      if (type_metadata == Qnil) {
-        type_metadata = rb_hash_aref(types, member);
-      }
-    }
-
-    if (tryToReadFromAliases) {
-      volatile VALUE alias_name = rb_hash_aref(aliases, member_raw);
-      if (alias_name != Qnil) {
-        member = rb_sym2str(alias_name);
-      }
-    }
-
-    func(obj, member, value, type_metadata, context);
+    func(obj, name_str, value, Qnil, context);
   }
 
   return Qnil;

--- a/ext/panko_serializer/attributes_iterator.h
+++ b/ext/panko_serializer/attributes_iterator.h
@@ -1,7 +1,9 @@
 #include <ruby.h>
 #include <stdbool.h>
 
+#include "attribute.h"
 #include "serialization_descriptor.h"
+#include "type_cast.h"
 
 typedef void (*EachAttributeFunc)(VALUE object,
                                   VALUE name,
@@ -11,7 +13,6 @@ typedef void (*EachAttributeFunc)(VALUE object,
 
 extern VALUE panko_each_attribute(VALUE object,
                                   VALUE attributes,
-                                  VALUE aliases,
                                   EachAttributeFunc func,
                                   VALUE context);
 

--- a/ext/panko_serializer/panko_serializer.h
+++ b/ext/panko_serializer/panko_serializer.h
@@ -1,7 +1,9 @@
 #include <ruby.h>
 
-#include "serialization_descriptor.h"
+#include "association.h"
+#include "attribute.h"
 #include "attributes_iterator.h"
+#include "serialization_descriptor.h"
 #include "type_cast.h"
 
 VALUE serialize_subject(VALUE key,

--- a/ext/panko_serializer/serialization_descriptor.h
+++ b/ext/panko_serializer/serialization_descriptor.h
@@ -10,7 +10,7 @@ typedef struct _SerializationDescriptor {
   VALUE serializer;
 
   // Metadata
-  VALUE fields;
+  VALUE attributes;
   VALUE aliases;
   VALUE method_fields;
   VALUE has_one_associations;
@@ -18,6 +18,10 @@ typedef struct _SerializationDescriptor {
 } * SerializationDescriptor;
 
 SerializationDescriptor sd_read(VALUE descriptor);
+
+static void sd_free(SerializationDescriptor sd);
+void sd_mark(SerializationDescriptor data);
+
 VALUE sd_build_serializer(SerializationDescriptor descriptor);
 void sd_apply_serializer_config(VALUE serializer, VALUE object, VALUE context);
 

--- a/ext/panko_serializer/type_cast.c
+++ b/ext/panko_serializer/type_cast.c
@@ -41,11 +41,25 @@ VALUE cache_postgres_type_lookup(VALUE ar) {
     return Qfalse;
   }
 
-  ar_pg_integer_type = rb_const_get_at(ar_oid, rb_intern("Integer"));
-  ar_pg_float_type = rb_const_get_at(ar_oid, rb_intern("Float"));
-  ar_pg_uuid_type = rb_const_get_at(ar_oid, rb_intern("Uuid"));
-  ar_pg_json_type = rb_const_get_at(ar_oid, rb_intern("Json"));
-  ar_pg_date_time_type = rb_const_get_at(ar_oid, rb_intern("DateTime"));
+  if(rb_const_defined_at(ar_oid, rb_intern("Float")) == (int)Qtrue) {
+    ar_pg_float_type = rb_const_get_at(ar_oid, rb_intern("Float"));
+  }
+
+  if(rb_const_defined_at(ar_oid, rb_intern("Integer")) == (int)Qtrue) {
+    ar_pg_integer_type = rb_const_get_at(ar_oid, rb_intern("Integer"));
+  }
+
+  if(rb_const_defined_at(ar_oid, rb_intern("Uuid")) == (int)Qtrue) {
+    ar_pg_uuid_type = rb_const_get_at(ar_oid, rb_intern("Uuid"));
+  }
+
+  if(rb_const_defined_at(ar_oid, rb_intern("Json")) == (int)Qtrue) {
+    ar_pg_json_type = rb_const_get_at(ar_oid, rb_intern("Json"));
+  }
+
+  if(rb_const_defined_at(ar_oid, rb_intern("DateTime")) == (int)Qtrue) {
+    ar_pg_date_time_type = rb_const_get_at(ar_oid, rb_intern("DateTime"));
+  }
 
   return Qtrue;
 }
@@ -94,7 +108,8 @@ void cache_type_lookup() {
   ar_date_time_type = rb_const_get_at(ar_type, rb_intern("DateTime"));
 
   ar_type_methods = rb_class_instance_methods(0, NULL, ar_string_type);
-  if(rb_ary_includes(ar_type_methods, rb_to_symbol(rb_str_new_cstr("deserialize")))) {
+  if (rb_ary_includes(ar_type_methods,
+                      rb_to_symbol(rb_str_new_cstr("deserialize")))) {
     deserialize_from_db_id = rb_intern("deserialize");
   } else {
     deserialize_from_db_id = rb_intern("type_cast_from_database");
@@ -247,16 +262,15 @@ VALUE cast_date_time_type(VALUE value) {
   return Qundef;
 }
 
-VALUE type_cast(VALUE type_metadata, VALUE value) {
+VALUE type_cast(VALUE type_klass, VALUE value) {
   if (value == Qnil || value == Qundef) {
     return value;
   }
 
   cache_type_lookup();
 
-  VALUE type_klass, typeCastedValue;
+  VALUE typeCastedValue;
 
-  type_klass = CLASS_OF(type_metadata);
   typeCastedValue = Qundef;
 
   TypeCast typeCast;
@@ -268,6 +282,8 @@ VALUE type_cast(VALUE type_metadata, VALUE value) {
   }
 
   if (typeCastedValue == Qundef) {
+    VALUE args[0];
+    volatile VALUE type_metadata = rb_class_new_instance(0, args, type_klass);
     return rb_funcall(type_metadata, deserialize_from_db_id, 1, value);
   }
 

--- a/ext/panko_serializer/type_cast.h
+++ b/ext/panko_serializer/type_cast.h
@@ -1,6 +1,9 @@
 #include <ruby.h>
 #include <stdbool.h>
 
+#ifndef __PANKO_TYPE_CAST_H__
+#define __PANKO_TYPE_CAST_H__
+
 /*
  * Type Casting
  *
@@ -72,3 +75,5 @@ static struct _TypeCast type_casts[] = {
 
 extern VALUE type_cast(VALUE type_metadata, VALUE value);
 void panko_init_type_cast(VALUE mPanko);
+
+#endif

--- a/lib/panko/attribute.rb
+++ b/lib/panko/attribute.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Panko
+  class Attribute
+    def self.create(name, alias_name: nil)
+      alias_name = alias_name.to_s unless alias_name.nil?
+      Attribute.new(name.to_s, alias_name)
+    end
+
+    def ==(attr)
+      return name.to_sym == attr if attr.is_a? Symbol
+      if attr.is_a? Panko::Attribute
+        return name == attr.name && alias_name == attr.alias_name
+      end
+      super
+    end
+
+    def hash
+      name.to_sym.hash
+    end
+
+    def eql?(attr)
+      self.==(attr)
+    end
+
+    def inspect
+      "<Panko::Attribute name=#{name.inspect} alias_name=#{alias_name.inspect}>"
+    end
+  end
+end

--- a/lib/panko_serializer.rb
+++ b/lib/panko_serializer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "panko/version"
+require "panko/attribute"
 require "panko/serializer"
 require "panko/array_serializer"
 require "panko/response"

--- a/spec/type_cast_spec.rb
+++ b/spec/type_cast_spec.rb
@@ -6,7 +6,7 @@ require "active_record/connection_adapters/postgresql_adapter"
 describe "Type Casting" do
   describe "String / Text" do
     context "ActiveRecord::Type::String" do
-      let(:type) { ActiveRecord::Type::String.new }
+      let(:type) { ActiveRecord::Type::String }
 
       it { expect(Panko._type_cast(type, true)).to          eq("t") }
       it { expect(Panko._type_cast(type, nil)).to           be_nil }
@@ -16,7 +16,7 @@ describe "Type Casting" do
     end
 
     context "ActiveRecord::Type::Text" do
-      let(:type) { ActiveRecord::Type::Text.new }
+      let(:type) { ActiveRecord::Type::Text }
 
       it { expect(Panko._type_cast(type, true)).to          eq("t") }
       it { expect(Panko._type_cast(type, false)).to         eq("f") }
@@ -26,7 +26,7 @@ describe "Type Casting" do
 
     # We treat uuid as stirng, there is no need for type cast before serialization
     context "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid" do
-      let(:type) { ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid.new }
+      let(:type) { ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid }
 
       it { expect(Panko._type_cast(type, "e67d284b-87b8-445e-a20d-3c76ea353866")).to eq("e67d284b-87b8-445e-a20d-3c76ea353866") }
     end
@@ -34,7 +34,7 @@ describe "Type Casting" do
 
   describe "Integer" do
     context "ActiveRecord::Type::Integer" do
-      let(:type) { ActiveRecord::Type::Integer.new }
+      let(:type) { ActiveRecord::Type::Integer }
 
       it { expect(Panko._type_cast(type, "")).to  be_nil }
       it { expect(Panko._type_cast(type, nil)).to be_nil }
@@ -51,7 +51,7 @@ describe "Type Casting" do
     end
 
     context "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer", if: ENV["RAILS_VERSION"].start_with?("4.2") do
-      let(:type) { ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer.new }
+      let(:type) { ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Integer }
 
       it { expect(Panko._type_cast(type, "")).to be_nil }
       it { expect(Panko._type_cast(type, nil)).to be_nil }
@@ -69,7 +69,7 @@ describe "Type Casting" do
   end
 
   context "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Json" do
-    let(:type) { ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Json.new }
+    let(:type) { ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Json }
 
     it { expect(Panko._type_cast(type, "")).to be_nil }
     it { expect(Panko._type_cast(type, "shnitzel")).to be_nil }
@@ -83,7 +83,7 @@ describe "Type Casting" do
   end
 
   context "ActiveRecord::Type::Boolean" do
-    let(:type) { ActiveRecord::Type::Boolean.new }
+    let(:type) { ActiveRecord::Type::Boolean }
 
     it { expect(Panko._type_cast(type, "")).to be_nil }
     it { expect(Panko._type_cast(type, nil)).to be_nil }
@@ -104,7 +104,7 @@ describe "Type Casting" do
   end
 
   context "Time" do
-    let(:type) { ActiveRecord::Type::DateTime.new }
+    let(:type) { ActiveRecord::Type::DateTime }
     let(:date) { DateTime.new(2017, 3, 4, 12, 45, 23) }
     let(:utc) { ActiveSupport::TimeZone.new("UTC") }
 


### PR DESCRIPTION
* Refactoring attributes reading code, to be much more simpler - by
creating context and separate function for reading specific attribute
* Changing attribute & association to be backed behind C struct - for
performance improvement
* Unifying `aliases` and `fields` to `attributes`
* Caching type in attribute and invalidating it when the record class is
changed.
* Adding freeing code to SerializationDescription (and new structs)