### PR TITLE
Remove byebug requirement from SerialResolver

### DIFF
--- a/lib/panko/serializer_resolver.rb
+++ b/lib/panko/serializer_resolver.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "byebug"
 
 class Panko::SerializerResolver
 


### PR DESCRIPTION
Because byebug is in the gemspec as a development dependency, requiring it here causes upstream apps to either fail to bundle or require byebug in production bundler groups.  Guessing it was left there by accident. 