### PR TITLE
Fix spelling mistake

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 * [Panko](../README.md)
-* [Getting Stated](getting-started.md)
+* [Getting Started](getting-started.md)
 * Reference
   * [Attributes](attributes.md)
   * [Associations](associations.md)


### PR DESCRIPTION
Small fix for a spelling error in the documentation's table of contents