### PR TITLE
ObjectWriter suport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "activesupport", rails_version
 gem "activemodel", rails_version
 gem "activerecord", rails_version, group: :test
 
+
 group :benchmarks do
   if raw_rails_version.include? "4.2"
     gem 'sqlite3', '~> 1.3.6'
@@ -41,4 +42,5 @@ group :development do
   gem "rake"
   gem "rspec", "~> 3.0"
   gem "rake-compiler"
+  gem "rubocop"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,7 @@ end
 
 RSpec::Core::RakeTask.new(:spec)
 Rake::Task[:spec].prerequisites << :compile
+Rake::Task[:compile].prerequisites << :clean
 
 task default: :spec
 

--- a/benchmarks/bm_object_writer.rb
+++ b/benchmarks/bm_object_writer.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require_relative "./benchmarking_support"
+require_relative "./app"
+
+Benchmark.run("ObjectWriter_OneProperty_PushValue") do
+  writer = Panko::ObjectWriter.new
+
+  writer.push_object
+  writer.push_value "value1", "key1"
+  writer.pop
+
+  writer.output
+end
+
+Benchmark.run("ObjectWriter_TwoProperty_PushValue") do
+  writer = Panko::ObjectWriter.new
+
+  writer.push_object
+  writer.push_value "value1", "key1"
+  writer.push_value "value2", "key2"
+  writer.pop
+
+  writer.output
+end
+
+Benchmark.run("ObjectWriter_OneProperty_PushValuePushKey") do
+  writer = Panko::ObjectWriter.new
+
+  writer.push_object
+  writer.push_key "key1"
+  writer.push_value "value1"
+  writer.pop
+
+  writer.output
+end
+
+Benchmark.run("ObjectWriter_TwoProperty_PushValuePushKey") do
+  writer = Panko::ObjectWriter.new
+
+  writer.push_object
+  writer.push_key "key1"
+  writer.push_value "value1"
+
+  writer.push_key "key2"
+  writer.push_value "value2"
+  writer.pop
+
+  writer.output
+end
+
+Benchmark.run("ObjectWriter_NestedObject") do
+  writer = Panko::ObjectWriter.new
+
+  writer.push_object
+  writer.push_value "value1", "key1"
+
+  writer.push_object "key2"
+  writer.push_value "value2", "key2"
+  writer.pop
+
+  writer.pop
+
+  writer.output
+end

--- a/benchmarks/bm_to_object.rb
+++ b/benchmarks/bm_to_object.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+require_relative "./benchmarking_support"
+require_relative "./app"
+require_relative "./setup"
+
+class PostWithAliasModel < ActiveRecord::Base
+  self.table_name = 'posts'
+
+  alias_attribute :new_id, :id
+  alias_attribute :new_body, :body
+  alias_attribute :new_title, :title
+  alias_attribute :new_author_id, :author_id
+  alias_attribute :new_created_at, :created_at
+end
+
+class PostWithAliasFastSerializer < Panko::Serializer
+  attributes :new_id, :new_body, :new_title, :new_author_id, :new_created_at
+end
+
+def benchmark_aliased(prefix, serializer, options = {})
+  posts = PostWithAliasModel.all.to_a
+  posts_50 = posts.first(50).to_a
+  data = { all: posts, small: posts_50 }
+
+  merged_options = options.merge(each_serializer: serializer)
+
+  Benchmark.run("Panko_#{prefix}_PostWithAliasModels_#{posts.count}") do
+    Panko::ArraySerializer.new(posts, merged_options).to_json
+  end
+
+  posts = PostWithAliasModel.all.to_a
+  posts_50 = posts.first(50).to_a
+  data = { all: posts, small: posts_50 }
+
+  Benchmark.run("Panko_#{prefix}_Posts_50") do
+    Panko::ArraySerializer.new(posts_50, merged_options).to_json
+  end
+end
+
+class AuthorFastSerializer < Panko::Serializer
+  attributes :id, :name
+end
+
+
+class PostFastSerializer < Panko::Serializer
+  attributes :id, :body, :title, :author_id, :created_at
+end
+
+class PostFastWithMethodCallSerializer < Panko::Serializer
+  attributes :id, :body, :title, :author_id, :created_at, :method_call
+
+  def method_call
+    object.id
+  end
+end
+
+class PostWithHasOneFastSerializer < Panko::Serializer
+  attributes :id, :body, :title, :author_id, :created_at
+
+  has_one :author, serializer: AuthorFastSerializer
+end
+
+class AuthorWithHasManyFastSerializer < Panko::Serializer
+  attributes :id, :name
+
+  has_many :posts, serializer: PostFastSerializer
+end
+
+
+def benchmark(prefix, serializer, options = {})
+  data = Benchmark.data
+  posts = data[:all]
+  posts_50 = data[:small]
+
+  merged_options = options.merge(each_serializer: serializer)
+
+  Benchmark.run("Panko_#{prefix}_Posts_#{posts.count}") do
+    Panko::ArraySerializer.new(posts, merged_options).to_a
+  end
+
+  data = Benchmark.data
+  posts = data[:all]
+  posts_50 = data[:small]
+
+  Benchmark.run("Panko_#{prefix}_Posts_50") do
+    Panko::ArraySerializer.new(posts_50, merged_options).to_a
+  end
+end
+
+
+
+benchmark "Simple", PostFastSerializer
+benchmark "HasOne", PostWithHasOneFastSerializer

--- a/ext/panko_serializer/attributes_writer/active_record.c
+++ b/ext/panko_serializer/attributes_writer/active_record.c
@@ -73,11 +73,12 @@ VALUE read_attribute(struct attributes attributes_ctx, Attribute attribute) {
   volatile VALUE member, value;
 
   member = attribute->name_str;
-  value = Qundef;
+  value = Qnil;
 
   if (attributes_ctx.shouldReadFromHash == true) {
     volatile VALUE attribute_metadata =
         rb_hash_aref(attributes_ctx.attributes_hash, member);
+
     if (attribute_metadata != Qnil) {
       value = rb_ivar_get(attribute_metadata, value_before_type_cast_id);
 
@@ -87,11 +88,8 @@ VALUE read_attribute(struct attributes attributes_ctx, Attribute attribute) {
     }
   }
 
-  if (value == Qundef && !NIL_P(attributes_ctx.values)) {
+  if (NIL_P(value) && !NIL_P(attributes_ctx.values)) {
     value = rb_hash_aref(attributes_ctx.values, member);
-    if (NIL_P(value)) {
-      value = Qundef;
-    }
   }
 
   if (NIL_P(attribute->type) && !NIL_P(value)) {

--- a/ext/panko_serializer/attributes_writer/active_record.c
+++ b/ext/panko_serializer/attributes_writer/active_record.c
@@ -51,14 +51,17 @@ struct attributes init_context(VALUE obj) {
   } else {
     volatile VALUE delegate_hash =
         rb_ivar_get(lazy_attributes_hash, delegate_hash_id);
+    size_t delegateHashSize = PANKO_SAFE_HASH_SIZE(delegate_hash);
 
-    if (PANKO_EMPTY_HASH(delegate_hash) == false) {
+    if (delegateHashSize > 0) {
       attributes_ctx.attributes_hash = delegate_hash;
-      attributes_ctx.shouldReadFromHash = true;
     }
 
     attributes_ctx.types = rb_ivar_get(lazy_attributes_hash, types_id);
     attributes_ctx.values = rb_ivar_get(lazy_attributes_hash, values_id);
+
+    size_t valuesHashSize = PANKO_SAFE_HASH_SIZE(attributes_ctx.values);
+    attributes_ctx.shouldReadFromHash = delegateHashSize > valuesHashSize;
 
     attributes_ctx.additional_types =
         rb_ivar_get(lazy_attributes_hash, additional_types_id);

--- a/ext/panko_serializer/common.h
+++ b/ext/panko_serializer/common.h
@@ -3,6 +3,9 @@
 #include <ruby.h>
 
 
+#define PANKO_SAFE_HASH_SIZE(hash) \
+  (hash == Qnil || hash == Qundef) ? 0 : RHASH_SIZE(hash)
+
 #define PANKO_EMPTY_HASH(hash) \
   (hash == Qnil || hash == Qundef) ? 1 : (RHASH_SIZE(hash) == 0)
 

--- a/ext/panko_serializer/serialization_descriptor/attribute.c
+++ b/ext/panko_serializer/serialization_descriptor/attribute.c
@@ -48,7 +48,7 @@ Attribute attribute_read(VALUE attribute) {
 }
 
 void attribute_try_invalidate(Attribute attribute, VALUE new_record_class) {
-  if (rb_equal(attribute->record_class, new_record_class) == Qfalse) {
+  if (attribute->record_class != new_record_class) {
     attribute->type = Qnil;
     attribute->record_class = new_record_class;
 

--- a/lib/panko/array_serializer.rb
+++ b/lib/panko/array_serializer.rb
@@ -2,10 +2,10 @@
 
 module Panko
   class ArraySerializer
-    attr_accessor :objects
+    attr_accessor :subjects
 
-    def initialize(objects, options = {})
-      @objects = objects
+    def initialize(subjects, options = {})
+      @subjects = subjects
       @each_serializer = options[:each_serializer]
 
       if @each_serializer.nil?
@@ -27,7 +27,7 @@ Please pass valid each_serializer to ArraySerializer, for example:
     end
 
     def to_json
-      serialize_to_json @objects
+      serialize_to_json @subjects
     end
 
     def serialize(subjects)
@@ -45,7 +45,7 @@ Please pass valid each_serializer to ArraySerializer, for example:
     private
 
     def serialize_with_writer(subjects, writer)
-      Panko.serialize_objects(objects.to_a, writer, @descriptor)
+      Panko.serialize_objects(subjects.to_a, writer, @descriptor)
       @descriptor.set_serialization_context(nil) unless @serialization_context.is_a?(EmptySerializerContext)
       writer
     end

--- a/lib/panko/array_serializer.rb
+++ b/lib/panko/array_serializer.rb
@@ -46,7 +46,6 @@ Please pass valid each_serializer to ArraySerializer, for example:
 
     def serialize_with_writer(subjects, writer)
       Panko.serialize_objects(subjects.to_a, writer, @descriptor)
-      @descriptor.set_serialization_context(nil) unless @serialization_context.is_a?(EmptySerializerContext)
       writer
     end
   end

--- a/lib/panko/array_serializer.rb
+++ b/lib/panko/array_serializer.rb
@@ -30,19 +30,24 @@ Please pass valid each_serializer to ArraySerializer, for example:
       serialize_to_json @objects
     end
 
-    def serialize(objects)
-      Oj.load(serialize_to_json(objects))
+    def serialize(subjects)
+      serialize_with_writer(subjects, Panko::ObjectWriter.new).output
     end
 
     def to_a
-      Oj.load(serialize_to_json(@objects))
+      serialize_with_writer(@subjects, Panko::ObjectWriter.new).output
     end
 
-    def serialize_to_json(objects)
-      writer = Oj::StringWriter.new(mode: :rails)
+    def serialize_to_json(subjects)
+      serialize_with_writer(subjects, Oj::StringWriter.new(mode: :rails)).to_s
+    end
+
+    private
+
+    def serialize_with_writer(subjects, writer)
       Panko.serialize_objects(objects.to_a, writer, @descriptor)
       @descriptor.set_serialization_context(nil) unless @serialization_context.is_a?(EmptySerializerContext)
-      writer.to_s
+      writer
     end
   end
 end

--- a/lib/panko/attribute.rb
+++ b/lib/panko/attribute.rb
@@ -10,6 +10,7 @@ module Panko
     def ==(attr)
       return name.to_sym == attr if attr.is_a? Symbol
       return name == attr.name && alias_name == attr.alias_name if attr.is_a? Panko::Attribute
+
       super
     end
 

--- a/lib/panko/object_writer.rb
+++ b/lib/panko/object_writer.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Panko::ObjectWriter
-  attr_reader :output
-
   def initialize
     @values = []
     @keys = []
@@ -26,10 +24,13 @@ class Panko::ObjectWriter
   end
 
   def push_value(value, key = nil)
-    key ||= @next_key
+    unless @next_key.nil?
+      raise "push_value is called with key after push_key is called" unless key.nil?
+      key = @next_key
+      @next_key = nil
+    end
 
     @values.last[key] = value
-    @next_key = nil
   end
 
   def pop
@@ -46,5 +47,10 @@ class Panko::ObjectWriter
     else
       @values.last[scope_key] = result
     end
+  end
+
+  def output
+    raise "Output is called before poping all" unless @values.empty?
+    @output
   end
 end

--- a/lib/panko/object_writer.rb
+++ b/lib/panko/object_writer.rb
@@ -30,7 +30,7 @@ class Panko::ObjectWriter
       @next_key = nil
     end
 
-    @values.last[key] = value
+    @values.last[key] = value.as_json
   end
 
   def pop

--- a/lib/panko/object_writer.rb
+++ b/lib/panko/object_writer.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class Panko::ObjectWriter
+  attr_reader :output
+
+  def initialize
+    @values = []
+    @keys = []
+
+    @next_key = nil
+    @output = nil
+  end
+
+  def push_object(key = nil)
+    @values << {}
+    @keys << key
+  end
+
+  def push_array(key = nil)
+    @values << []
+    @keys << key
+  end
+
+  def push_key(key)
+    @next_key = key
+  end
+
+  def push_value(value, key = nil)
+    key ||= @next_key
+
+    @values.last[key] = value
+    @next_key = nil
+  end
+
+  def pop
+    result = @values.pop
+
+    if @values.empty?
+      @output = result
+      return
+    end
+
+    scope_key = @keys.pop
+    if scope_key.nil?
+      @values.last << result
+    else
+      @values.last[scope_key] = result
+    end
+  end
+end

--- a/lib/panko/serializer.rb
+++ b/lib/panko/serializer.rb
@@ -64,6 +64,7 @@ module Panko
 
       def method_added(method)
         return if @_descriptor.nil?
+
         deleted_attr = @_descriptor.attributes.delete(method)
         @_descriptor.method_fields << Attribute.create(method) unless deleted_attr.nil?
       end
@@ -115,14 +116,19 @@ module Panko
     attr_reader :object
 
     def serialize(object)
-      Oj.load(serialize_to_json(object))
+      Oj.load serialize_with_writer(object, Oj::StringWriter.new(mode: :rails)).to_s
     end
 
     def serialize_to_json(object)
-      writer = Oj::StringWriter.new(mode: :rails)
+      serialize_with_writer(object, Oj::StringWriter.new(mode: :rails)).to_s
+    end
+
+    private
+
+    def serialize_with_writer(object, writer)
       Panko.serialize_object(object, writer, @descriptor)
       @descriptor.set_serialization_context(nil) unless @serialization_context.is_a?(EmptySerializerContext)
-      writer.to_s
+      writer
     end
   end
 end

--- a/lib/panko/serializer.rb
+++ b/lib/panko/serializer.rb
@@ -116,7 +116,7 @@ module Panko
     attr_reader :object
 
     def serialize(object)
-      Oj.load serialize_with_writer(object, Oj::StringWriter.new(mode: :rails)).to_s
+      serialize_with_writer(object, Panko::ObjectWriter.new).output
     end
 
     def serialize_to_json(object)
@@ -127,7 +127,6 @@ module Panko
 
     def serialize_with_writer(object, writer)
       Panko.serialize_object(object, writer, @descriptor)
-      @descriptor.set_serialization_context(nil) unless @serialization_context.is_a?(EmptySerializerContext)
       writer
     end
   end

--- a/lib/panko_serializer.rb
+++ b/lib/panko_serializer.rb
@@ -7,6 +7,7 @@ require "panko/serializer"
 require "panko/array_serializer"
 require "panko/response"
 require "panko/serializer_resolver"
+require "panko/object_writer"
 
 # C Extension
 require "oj"

--- a/spec/panko/array_serializer_spec.rb
+++ b/spec/panko/array_serializer_spec.rb
@@ -20,12 +20,10 @@ describe Panko::ArraySerializer do
       foo1 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
       foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
 
-      output = array_serializer.serialize Foo.all
-
-      expect(output).to eq([
-                             { "name" => foo1.name, "address" => foo1.address },
-                             { "name" => foo2.name, "address" => foo2.address }
-                           ])
+      expect(Foo.all).to serialized_as(array_serializer, [
+                                         { "name" => foo1.name, "address" => foo1.address },
+                                         { "name" => foo2.name, "address" => foo2.address }
+                                       ])
     end
 
     it "serializes array of elements with virtual attribtues" do
@@ -47,12 +45,10 @@ describe Panko::ArraySerializer do
                                                     each_serializer: TestSerializerWithMethodsSerializer,
                                                     context: { value: 6 })
 
-      output = array_serializer.serialize Foo.all
-
-      expect(output.first).to eq("name" => foo.name,
-                                 "address" => foo.address,
-                                 "something" => "#{foo.name} #{foo.address}",
-                                 "context_fetch" => 6)
+      expect(Foo.all).to serialized_as(array_serializer, [{ "name" => foo.name,
+                                                            "address" => foo.address,
+                                                            "something" => "#{foo.name} #{foo.address}",
+                                                            "context_fetch" => 6 }])
     end
   end
 
@@ -63,12 +59,10 @@ describe Panko::ArraySerializer do
       foo1 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
       foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
 
-      output = array_serializer.serialize Foo.all
-
-      expect(output).to eq([
-                             { "name" => foo1.name },
-                             { "name" => foo2.name }
-                           ])
+      expect(Foo.all).to serialized_as(array_serializer, [
+                                         { "name" => foo1.name },
+                                         { "name" => foo2.name }
+                                       ])
     end
 
     it "except" do
@@ -77,12 +71,10 @@ describe Panko::ArraySerializer do
       foo1 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
       foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
 
-      output = array_serializer.serialize Foo.all
-
-      expect(output).to eq([
-                             { "address" => foo1.address },
-                             { "address" => foo2.address }
-                           ])
+      expect(Foo.all).to serialized_as(array_serializer, [
+                                         { "address" => foo1.address },
+                                         { "address" => foo2.address }
+                                       ])
     end
   end
 end

--- a/spec/panko/object_writer_spec.rb
+++ b/spec/panko/object_writer_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "active_record/connection_adapters/postgresql_adapter"
+
+describe Panko::ObjectWriter do
+  let(:writer) { Panko::ObjectWriter.new }
+
+  context "push_object" do
+    it "property" do
+      writer.push_object
+      writer.push_value "yosi", "name"
+      writer.pop
+
+      expect(writer.output).to eql("name" => "yosi")
+    end
+
+    it "property with separate key value instructions" do
+      writer.push_object
+      writer.push_key "name"
+      writer.push_value "yosi"
+      writer.pop
+
+      expect(writer.output).to eql("name" => "yosi")
+    end
+
+    it "supports nested objects" do
+      writer.push_object
+      writer.push_value "yosi", "name"
+
+      writer.push_object("nested")
+      writer.push_value "key1", "value"
+      writer.pop
+
+      writer.pop
+
+      expect(writer.output).to eql(
+        "name" => "yosi",
+        "nested" => {
+          "value" => "key1"
+        }
+      )
+    end
+
+    it "supports nested arrays" do
+      writer.push_object
+      writer.push_value "yosi", "name"
+
+      writer.push_object("nested")
+      writer.push_value "key1", "value"
+      writer.pop
+
+      writer.push_array "values"
+      writer.push_object
+      writer.push_value "item", "key"
+      writer.pop
+      writer.pop
+
+      writer.pop
+
+      expect(writer.output).to eql(
+        "name" => "yosi",
+        "nested" => {
+          "value" => "key1"
+        },
+        "values" => [
+          { "key" => "item" }
+        ]
+      )
+    end
+  end
+
+  it "supports arrays" do
+    writer.push_array
+
+    writer.push_object
+    writer.push_value "key1", "value"
+    writer.pop
+
+    writer.push_object
+    writer.push_value "key2", "value2"
+    writer.pop
+
+    writer.pop
+
+    expect(writer.output).to eql([
+                                   {
+                                     "value" => "key1"
+                                   },
+                                   {
+                                     "value2" => "key2"
+                                   }
+                                 ])
+  end
+end

--- a/spec/panko/response_spec.rb
+++ b/spec/panko/response_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 
 describe Panko::Response do

--- a/spec/panko/serializer_spec.rb
+++ b/spec/panko/serializer_spec.rb
@@ -13,20 +13,18 @@ describe Panko::Serializer do
       serializer = FooSerializer.new
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
 
-      output = serializer.serialize foo
-
-      expect(output).to eq("name" => foo.name,
-                           "address" => foo.address)
+      expect(foo).to serialized_as(serializer,
+                                   "name" => foo.name,
+                                   "address" => foo.address)
     end
 
     it "from memory" do
       serializer = FooSerializer.new
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
 
-      output = serializer.serialize foo
-
-      expect(output).to eq("name" => foo.name,
-                           "address" => foo.address)
+      expect(foo).to serialized_as(serializer,
+                                   "name" => foo.name,
+                                   "address" => foo.address)
     end
 
     it "plain object" do
@@ -42,10 +40,9 @@ describe Panko::Serializer do
       serializer = FooSerializer.new
       foo = PlainFoo.new(Faker::Lorem.word, Faker::Lorem.word)
 
-      output = serializer.serialize foo
-
-      expect(output).to eq("name" => foo.name,
-                           "address" => foo.address)
+      expect(foo).to serialized_as(serializer,
+                                   "name" => foo.name,
+                                   "address" => foo.address)
     end
   end
 
@@ -54,10 +51,9 @@ describe Panko::Serializer do
       serializer = FooSerializer.new
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
 
-      output = serializer.serialize foo
-
-      expect(output).to eq("name" => foo.name,
-                           "address" => foo.address)
+      expect(foo).to serialized_as(serializer,
+                                   "name" => foo.name,
+                                   "address" => foo.address)
     end
 
     it "method attributes" do
@@ -76,11 +72,10 @@ describe Panko::Serializer do
       serializer = FooWithMethodsSerializer.new
 
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
-      output = serializer.serialize foo
 
-      expect(output).to eq("name" => foo.name,
-                           "address" => foo.address,
-                           "something" => "#{foo.name} #{foo.address}")
+      expect(foo).to serialized_as(serializer, "name" => foo.name,
+                                               "address" => foo.address,
+                                               "something" => "#{foo.name} #{foo.address}")
     end
 
     it "supports serailizer inheritance" do
@@ -95,10 +90,9 @@ describe Panko::Serializer do
       serializer = ChildSerializer.new
 
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
-      output = serializer.serialize foo
 
-      expect(output).to eq("name" => foo.name,
-                           "address" => foo.address)
+      expect(foo).to serialized_as(serializer, "name" => foo.name,
+                                               "address" => foo.address)
     end
 
     it "serializes time correctly" do
@@ -111,12 +105,10 @@ describe Panko::Serializer do
       end
 
       obj = Foo.create.reload
-      output = ObjectWithTimeSerializer.new.serialize obj
 
-      expect(output).to eq(
-        "created_at" => obj.created_at.as_json,
-        "method" => obj.created_at.as_json
-      )
+      expect(obj).to serialized_as(ObjectWithTimeSerializer.new,
+                                   "created_at" => obj.created_at.as_json,
+                                   "method" => obj.created_at.as_json)
     end
 
     it "honors additional types" do
@@ -127,9 +119,7 @@ describe Panko::Serializer do
       foo = Foo.instantiate({ "value" => "1" },
                             "value" => ActiveRecord::Type::Integer.new)
 
-      output = FooValueSerializer.new.serialize foo
-
-      expect(output).to eq("value" => 1)
+      expect(foo).to serialized_as(FooValueSerializer.new, "value" => 1)
     end
 
     it "supports active record alias attributes" do
@@ -143,11 +133,8 @@ describe Panko::Serializer do
       end
 
       foo = FooWithAliasesModel.create(full_name: Faker::Lorem.word, address: Faker::Lorem.word).reload
-      serializer = FooWithArAliasesSerializer.new
-      output = serializer.serialize foo
 
-      expect(output).to eq("full_name" => foo.name,
-                           "address" => foo.address)
+      expect(foo).to serialized_as(FooWithArAliasesSerializer.new, "full_name" => foo.name, "address" => foo.address)
     end
 
     it "allows to alias attributes" do
@@ -157,21 +144,13 @@ describe Panko::Serializer do
         aliases name: :full_name
       end
 
-      serializer = FooWithAliasesSerializer.new
-
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
-      output = serializer.serialize foo
 
-      expect(output).to eq("full_name" => foo.name,
-                           "address" => foo.address)
+      expect(foo).to serialized_as(FooWithAliasesSerializer.new, "full_name" => foo.name, "address" => foo.address)
     end
 
     it "serializes null values" do
-      serializer = FooSerializer.new
-
-      output = serializer.serialize Foo.create
-
-      expect(output).to eq("name" => nil, "address" => nil)
+      expect(Foo.create).to serialized_as(FooSerializer.new, "name" => nil, "address" => nil)
     end
 
     it "preserves changed attributes" do
@@ -179,13 +158,9 @@ describe Panko::Serializer do
 
       foo.update!(name: "This is a new name")
 
-      serializer = FooSerializer.new
-
-      output = serializer.serialize foo
-      expect(output).to eq(
-        "name" => "This is a new name",
-        "address" => foo.address
-      )
+      expect(foo).to serialized_as(FooSerializer.new,
+                                   "name" => "This is a new name",
+                                   "address" => foo.address)
     end
   end
 
@@ -203,10 +178,9 @@ describe Panko::Serializer do
       serializer = FooWithContextSerializer.new(context: context)
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
 
-      output = serializer.serialize foo
-
-      expect(output).to eq("name" => foo.name,
-                           "context_value" => context[:value])
+      expect(foo).to serialized_as(serializer,
+                                   "name" => foo.name,
+                                   "context_value" => context[:value])
     end
   end
 
@@ -236,12 +210,11 @@ describe Panko::Serializer do
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
       foo_holder = FooHolder.create(name: Faker::Lorem.word, foo: foo).reload
 
-      output = serializer.serialize foo_holder
-
-      expect(output).to eql("scope_value" => scope,
-                            "foo" => {
-                              "scope_value" => scope
-                            })
+      expect(foo_holder).to serialized_as(serializer,
+                                          "scope_value" => scope,
+                                          "foo" => {
+                                            "scope_value" => scope
+                                          })
     end
 
     it "default scope is nil" do
@@ -250,12 +223,10 @@ describe Panko::Serializer do
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
       foo_holder = FooHolder.create(name: Faker::Lorem.word, foo: foo).reload
 
-      output = serializer.serialize foo_holder
-
-      expect(output).to eql("scope_value" => nil,
-                            "foo" => {
-                              "scope_value" => nil
-                            })
+      expect(foo_holder).to serialized_as(serializer, "scope_value" => nil,
+                                                      "foo" => {
+                                                        "scope_value" => nil
+                                                      })
     end
   end
 
@@ -264,18 +235,14 @@ describe Panko::Serializer do
       serializer = FooSerializer.new(only: [:name])
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
 
-      output = serializer.serialize foo
-
-      expect(output).to eq("name" => foo.name)
+      expect(foo).to serialized_as(serializer, "name" => foo.name)
     end
 
     it "except" do
       serializer = FooSerializer.new(except: [:name])
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
 
-      output = serializer.serialize foo
-
-      expect(output).to eq("address" => foo.address)
+      expect(foo).to serialized_as(serializer, "address" => foo.address)
     end
   end
 
@@ -310,13 +277,11 @@ describe Panko::Serializer do
       foo = PlainFoo.new(Faker::Lorem.word, Faker::Lorem.word)
       foo_holder = PlainFooHolder.new(Faker::Lorem.word, foo)
 
-      output = serializer.serialize foo_holder
-
-      expect(output).to eq("name" => foo_holder.name,
-                           "foo" => {
-                             "name" => foo.name,
-                             "address" => foo.address
-                           })
+      expect(foo_holder).to serialized_as(serializer, "name" => foo_holder.name,
+                                                      "foo" => {
+                                                        "name" => foo.name,
+                                                        "address" => foo.address
+                                                      })
     end
 
     it "accepts name option" do
@@ -331,13 +296,11 @@ describe Panko::Serializer do
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
       foo_holder = FooHolder.create(name: Faker::Lorem.word, foo: foo).reload
 
-      output = serializer.serialize foo_holder
-
-      expect(output).to eq("name" => foo_holder.name,
-                           "my_foo" => {
-                             "name" => foo.name,
-                             "address" => foo.address
-                           })
+      expect(foo_holder).to serialized_as(serializer, "name" => foo_holder.name,
+                                                      "my_foo" => {
+                                                        "name" => foo.name,
+                                                        "address" => foo.address
+                                                      })
     end
     it "serializes using the :serializer option" do
       class FooHolderHasOneSerializer < Panko::Serializer
@@ -351,13 +314,11 @@ describe Panko::Serializer do
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
       foo_holder = FooHolder.create(name: Faker::Lorem.word, foo: foo).reload
 
-      output = serializer.serialize foo_holder
-
-      expect(output).to eq("name" => foo_holder.name,
-                           "foo" => {
-                             "name" => foo.name,
-                             "address" => foo.address
-                           })
+      expect(foo_holder).to serialized_as(serializer, "name" => foo_holder.name,
+                                                      "foo" => {
+                                                        "name" => foo.name,
+                                                        "address" => foo.address
+                                                      })
     end
 
     it "infers the serializer name by name of the realtionship" do
@@ -372,13 +333,11 @@ describe Panko::Serializer do
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
       foo_holder = FooHolder.create(name: Faker::Lorem.word, foo: foo).reload
 
-      output = serializer.serialize foo_holder
-
-      expect(output).to eq("name" => foo_holder.name,
-                           "foo" => {
-                             "name" => foo.name,
-                             "address" => foo.address
-                           })
+      expect(foo_holder).to serialized_as(serializer, "name" => foo_holder.name,
+                                                      "foo" => {
+                                                        "name" => foo.name,
+                                                        "address" => foo.address
+                                                      })
     end
 
     it "raises if it can't find the serializer" do
@@ -411,12 +370,10 @@ describe Panko::Serializer do
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
       foo_holder = FooHolder.create(name: Faker::Lorem.word, foo: foo).reload
 
-      output = serializer.serialize foo_holder
-
-      expect(output).to eq("name" => foo_holder.name,
-                           "foo" => {
-                             "virtual" => "Hello #{foo.name}"
-                           })
+      expect(foo_holder).to serialized_as(serializer, "name" => foo_holder.name,
+                                                      "foo" => {
+                                                        "virtual" => "Hello #{foo.name}"
+                                                      })
     end
 
     it "handles nil" do
@@ -430,10 +387,8 @@ describe Panko::Serializer do
 
       foo_holder = FooHolder.create(name: Faker::Lorem.word, foo: nil).reload
 
-      output = serializer.serialize foo_holder
-
-      expect(output).to eq("name" => foo_holder.name,
-                           "foo" => nil)
+      expect(foo_holder).to serialized_as(serializer, "name" => foo_holder.name,
+                                                      "foo" => nil)
     end
   end
 
@@ -451,19 +406,17 @@ describe Panko::Serializer do
       foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
       foos_holder = FoosHolder.create(name: Faker::Lorem.word, foos: [foo1, foo2]).reload
 
-      output = serializer.serialize foos_holder
-
-      expect(output).to eq("name" => foos_holder.name,
-                           "foos" => [
-                             {
-                               "name" => foo1.name,
-                               "address" => foo1.address
-                             },
-                             {
-                               "name" => foo2.name,
-                               "address" => foo2.address
-                             }
-                           ])
+      expect(foos_holder).to serialized_as(serializer, "name" => foos_holder.name,
+                                                       "foos" => [
+                                                         {
+                                                           "name" => foo1.name,
+                                                           "address" => foo1.address
+                                                         },
+                                                         {
+                                                           "name" => foo2.name,
+                                                           "address" => foo2.address
+                                                         }
+                                                       ])
     end
 
     it "supports :name" do
@@ -479,19 +432,17 @@ describe Panko::Serializer do
       foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
       foos_holder = FoosHolder.create(name: Faker::Lorem.word, foos: [foo1, foo2]).reload
 
-      output = serializer.serialize foos_holder
-
-      expect(output).to eq("name" => foos_holder.name,
-                           "my_foos" => [
-                             {
-                               "name" => foo1.name,
-                               "address" => foo1.address
-                             },
-                             {
-                               "name" => foo2.name,
-                               "address" => foo2.address
-                             }
-                           ])
+      expect(foos_holder).to serialized_as(serializer, "name" => foos_holder.name,
+                                                       "my_foos" => [
+                                                         {
+                                                           "name" => foo1.name,
+                                                           "address" => foo1.address
+                                                         },
+                                                         {
+                                                           "name" => foo2.name,
+                                                           "address" => foo2.address
+                                                         }
+                                                       ])
     end
     it "infers the serializer name by name of the realtionship" do
       class FoosHasManyHolderSerializer < Panko::Serializer
@@ -506,19 +457,17 @@ describe Panko::Serializer do
       foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
       foos_holder = FoosHolder.create(name: Faker::Lorem.word, foos: [foo1, foo2]).reload
 
-      output = serializer.serialize foos_holder
-
-      expect(output).to eq("name" => foos_holder.name,
-                           "foos" => [
-                             {
-                               "name" => foo1.name,
-                               "address" => foo1.address
-                             },
-                             {
-                               "name" => foo2.name,
-                               "address" => foo2.address
-                             }
-                           ])
+      expect(foos_holder).to serialized_as(serializer, "name" => foos_holder.name,
+                                                       "foos" => [
+                                                         {
+                                                           "name" => foo1.name,
+                                                           "address" => foo1.address
+                                                         },
+                                                         {
+                                                           "name" => foo2.name,
+                                                           "address" => foo2.address
+                                                         }
+                                                       ])
     end
 
     it "raises if it can't find the serializer" do
@@ -544,19 +493,17 @@ describe Panko::Serializer do
       foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
       foos_holder = FoosHolder.create(name: Faker::Lorem.word, foos: [foo1, foo2]).reload
 
-      output = serializer.serialize foos_holder
-
-      expect(output).to eq("name" => foos_holder.name,
-                           "foos" => [
-                             {
-                               "name" => foo1.name,
-                               "address" => foo1.address
-                             },
-                             {
-                               "name" => foo2.name,
-                               "address" => foo2.address
-                             }
-                           ])
+      expect(foos_holder).to serialized_as(serializer, "name" => foos_holder.name,
+                                                       "foos" => [
+                                                         {
+                                                           "name" => foo1.name,
+                                                           "address" => foo1.address
+                                                         },
+                                                         {
+                                                           "name" => foo2.name,
+                                                           "address" => foo2.address
+                                                         }
+                                                       ])
     end
 
     it "accepts only as option" do
@@ -572,17 +519,15 @@ describe Panko::Serializer do
       foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
       foos_holder = FoosHolder.create(name: Faker::Lorem.word, foos: [foo1, foo2]).reload
 
-      output = serializer.serialize foos_holder
-
-      expect(output).to eq("name" => foos_holder.name,
-                           "foos" => [
-                             {
-                               "address" => foo1.address
-                             },
-                             {
-                               "address" => foo2.address
-                             }
-                           ])
+      expect(foos_holder).to serialized_as(serializer, "name" => foos_holder.name,
+                                                       "foos" => [
+                                                         {
+                                                           "address" => foo1.address
+                                                         },
+                                                         {
+                                                           "address" => foo2.address
+                                                         }
+                                                       ])
     end
 
     it "filters associations" do
@@ -598,18 +543,16 @@ describe Panko::Serializer do
       foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
       foos_holder = FoosHolder.create(name: Faker::Lorem.word, foos: [foo1, foo2]).reload
 
-      output = serializer.serialize foos_holder
-
-      expect(output).to eq("foos" => [
-                             {
-                               "name" => foo1.name,
-                               "address" => foo1.address
-                             },
-                             {
-                               "name" => foo2.name,
-                               "address" => foo2.address
-                             }
-                           ])
+      expect(foos_holder).to serialized_as(serializer, "foos" => [
+                                             {
+                                               "name" => foo1.name,
+                                               "address" => foo1.address
+                                             },
+                                             {
+                                               "name" => foo2.name,
+                                               "address" => foo2.address
+                                             }
+                                           ])
     end
 
     it "fetches the the filters from the serializer" do
@@ -626,9 +569,7 @@ describe Panko::Serializer do
       serializer = FooWithFiltersForSerializer.new
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
 
-      output = serializer.serialize foo
-
-      expect(output).to eq("name" => foo.name)
+      expect(foo).to serialized_as(serializer, "name" => foo.name)
     end
 
     it 'support nested "only" filter' do
@@ -643,17 +584,15 @@ describe Panko::Serializer do
       foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
       foos_holder = FoosHolder.create(name: Faker::Lorem.word, foos: [foo1, foo2]).reload
 
-      output = serializer.serialize foos_holder
-
-      expect(output).to eq("name" => foos_holder.name,
-                           "foos" => [
-                             {
-                               "address" => foo1.address
-                             },
-                             {
-                               "address" => foo2.address
-                             }
-                           ])
+      expect(foos_holder).to serialized_as(serializer, "name" => foos_holder.name,
+                                                       "foos" => [
+                                                         {
+                                                           "address" => foo1.address
+                                                         },
+                                                         {
+                                                           "address" => foo2.address
+                                                         }
+                                                       ])
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,3 +33,25 @@ RSpec.configure do |config|
     Foo.delete_all
   end
 end
+
+RSpec::Matchers.define :serialized_as do |serializer, output|
+  match do |object|
+    expect(serializer.serialize(object)).to eq(output)
+
+    json = Oj.load serializer.serialize_to_json(object)
+    expect(json).to eq(output)
+  end
+
+  failure_message do |object|
+    <<~FAILURE
+
+      Expected Output:
+      #{output}
+
+      Got:
+
+      Object: #{serializer.serialize(object)}
+      JSON: #{Oj.load(serializer.serialize_to_json(object))}
+    FAILURE
+  end
+end


### PR DESCRIPTION
Add native support for serializing to array of hashes, which improves performance.

 Master:
```
{"label":"Panko_Simple_Posts_2300","ips":"94.99","allocs":"27757/14"}
{"label":"Panko_Simple_Posts_50","ips":"4,602.76","allocs":"621/0"}
{"label":"Panko_HasOne_Posts_2300","ips":"48.85","allocs":"41429/0"}
{"label":"Panko_HasOne_Posts_50","ips":"2,806.27","allocs":"929/0"}
```

This branch:
```
{"label":"Panko_Simple_Posts_2300","ips":"142.33","allocs":"4756/14"}
{"label":"Panko_Simple_Posts_50","ips":"6,429.52","allocs":"120/0"}
{"label":"Panko_HasOne_Posts_2300","ips":"68.87","allocs":"9228/0"}
{"label":"Panko_HasOne_Posts_50","ips":"3,447.5","allocs":"228/0"}
```

running with ruby 2.6.3

