### PR TITLE
Rails 4.2 bug with dirty records

### DIFF
--- a/spec/panko/serializer_spec.rb
+++ b/spec/panko/serializer_spec.rb
@@ -174,6 +174,20 @@ describe Panko::Serializer do
 
       expect(output).to eq("name" => nil, "address" => nil)
     end
+
+    it "preserves changed attributes" do
+      foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
+
+      foo.update!(name: "This is a new name")
+
+      serializer = FooSerializer.new
+
+      output = serializer.serialize foo
+      expect(output).to eq(
+        "name" => "This is a new name",
+        "address" => foo.address
+      )
+    end
   end
 
   context "context" do


### PR DESCRIPTION
Hi @yosiat! Thanks for the gem! Finally, I got a change to give it a try.

Unfortunately, I'm still on Rails 4.2. Found a bug with serializing _dirty_ records: `@values` is not updated, which results in the older values present in the resulting hash.

Added a failing test.

Any ideas on how to fix this? (except from nullifying `@values` to bypass [this check](https://github.com/yosiat/panko_serializer/blob/master/ext/panko_serializer/attributes_writer/active_record.c#L90)🙂)

Couldn't find a relevant Rails commit (which changed this behaviour from Rails 4 to Rails 5) so far.