### PR TITLE
add group

### DIFF
--- a/lib/panko/array_serializer.rb
+++ b/lib/panko/array_serializer.rb
@@ -19,7 +19,8 @@ Please pass valid each_serializer to ArraySerializer, for example:
         only: options.fetch(:only, []),
         except: options.fetch(:except, []),
         context: options[:context],
-        scope: options[:scope]
+        scope: options[:scope],
+        group: options[:group]
       }
 
       @serialization_context = SerializationContext.create(options)

--- a/lib/panko/group.rb
+++ b/lib/panko/group.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Panko
+  class Group
+    attr_accessor :serializer
+    attr_accessor :fields
+
+    def initialize(serializer: nil, fields: [])
+      self.serializer = serializer
+      self.fields     = fields
+    end
+
+    def make_filter
+      {only: fields.uniq + serializer._default_attributes}
+    end
+  end
+end

--- a/lib/panko/group.rb
+++ b/lib/panko/group.rb
@@ -4,10 +4,12 @@ module Panko
   class Group
     attr_accessor :serializer
     attr_accessor :fields
+    attr_accessor :block
 
-    def initialize(serializer: nil, fields: [])
+    def initialize(serializer: nil, fields: [], block: ->{})
       self.serializer = serializer
       self.fields     = fields
+      self.block      = block
     end
 
     def make_filter

--- a/lib/panko/serialization_descriptor.rb
+++ b/lib/panko/serialization_descriptor.rb
@@ -7,9 +7,10 @@ module Panko
     # on the new descriptor
     #
     def self.build(serializer, options = {}, serialization_context = nil)
-      backend = Panko::SerializationDescriptor.duplicate(serializer._descriptor)
-
+      options.merge! serializer.send(:filters_for_groups, options[:group])
       options.merge! serializer.filters_for(options[:context], options[:scope]) if serializer.respond_to? :filters_for
+      
+      backend = Panko::SerializationDescriptor.duplicate(serializer._descriptor)
 
       backend.apply_filters(options)
 

--- a/lib/panko/serialization_descriptor.rb
+++ b/lib/panko/serialization_descriptor.rb
@@ -7,8 +7,8 @@ module Panko
     # on the new descriptor
     #
     def self.build(serializer, options = {}, serialization_context = nil)
-      options.merge! serializer.send(:filters_for_groups, options[:group])
       options.merge! serializer.filters_for(options[:context], options[:scope]) if serializer.respond_to? :filters_for
+      options.merge! serializer.send(:filters_for_groups, options[:group]) if options[:only].nil? || options[:only].empty?
       
       backend = Panko::SerializationDescriptor.duplicate(serializer._descriptor)
 

--- a/lib/panko/serializer.rb
+++ b/lib/panko/serializer.rb
@@ -112,7 +112,7 @@ module Panko
       private
 
       def filters_for_groups(group)
-        return {only: _default_attributes} if !@_groups[group] or !group
+        return {only: _default_attributes} if !@_groups&.method(:[])&.call(group) or !group
         @_groups[group].make_filter()
       end
 

--- a/lib/panko/serializer.rb
+++ b/lib/panko/serializer.rb
@@ -53,6 +53,7 @@ module Panko
           base._descriptor = Panko::SerializationDescriptor.duplicate(_descriptor)
         end
         base._descriptor.type = base
+        base._default_attributes += _default_attributes
       end
 
       attr_accessor :_descriptor
@@ -70,8 +71,9 @@ module Panko
 
       def aliases(aliases = {})
         aliases.each do |attr, alias_name|
-          @_descriptor.attributes << Attribute.create(attr, alias_name: alias_name)
+          self._default_attributes << alias_name
         end
+        _aliases(aliases)
       end
 
       def method_added(method)
@@ -128,6 +130,12 @@ module Panko
           @_groups                    ||= {}
           @_groups[group_name.to_sym] ||= Group.new(serializer: self)
           @_groups[group_name.to_sym].fields << value
+        end
+      end
+
+      def _aliases(aliases = {})
+        aliases.each do |attr, alias_name|
+          @_descriptor.attributes << Attribute.create(attr, alias_name: alias_name)
         end
       end
 

--- a/lib/panko/serializer.rb
+++ b/lib/panko/serializer.rb
@@ -4,16 +4,17 @@ require_relative "serialization_descriptor"
 require "oj"
 
 class SerializationContext
-  attr_accessor :context, :scope
+  attr_accessor :context, :scope, :group
 
-  def initialize(context, scope)
+  def initialize(context, scope, group)
     @context = context
     @scope = scope
+    @group = group
   end
 
   def self.create(options)
-    if options.key?(:context) || options.key?(:scope)
-      SerializationContext.new(options[:context], options[:scope])
+    if options.key?(:context) || options.key?(:scope) || options.key?(:group)
+      SerializationContext.new(options[:context], options[:scope], options[:group])
     else
       EmptySerializerContext.new
     end
@@ -26,6 +27,10 @@ class EmptySerializerContext
   end
 
   def context
+    nil
+  end
+
+  def group
     nil
   end
 end
@@ -171,6 +176,10 @@ module Panko
 
     def scope
       @serialization_context.scope
+    end
+
+    def group
+      @serialization_context.group
     end
 
     attr_writer :serialization_context

--- a/lib/panko_serializer.rb
+++ b/lib/panko_serializer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "panko/version"
+require "panko/group"
 require "panko/attribute"
 require "panko/association"
 require "panko/serializer"


### PR DESCRIPTION
my english very bad...
I created this pull request for add a group functional inside serializers
for example:

```ruby
class UserSerializer < Panko::Serializer
  attributes  :id, :name, :age

  # 1. combinations groups
  group(:full_info, :full_info_with_avatars) do
    group_attributes :full_name
    group_has_one :address, serializer: AddressSerializer

    def full_name
      "#{object.name}  #{object.last_name}"
    end
  end

  group(:full_info_with_avatars) do
    group_has_many :avatars, serializer: AvatarSerializer
  end


  # 2. pass group to next serializer
  group(:posts) do
    group_attributes :posts

    def posts 
      Panko::ArraySerializer.new(user.posts.last(5), group: group, each_serializer: PostSerializer).to_a
    end
  end


  # 3. same and different methods with equal names
  group(:test_1) do
    group_attributes :comments, :favorite_language, :some_field

    def comments
      _comments
    end

    def favorite_language
      _favorite_language
    end
  end

  group(:test_2) do
    group_attributes :comments, :favorite_language, :another_some_field

    def comments
      _comments
    end

    def favorite_language
      _favorite_language
    end
  end


  def  _comments
    Panko::ArraySerializer.new(user.comments, group: group, each_serializer: CommentSerializer).to_a
  end

  def _favorite_language
    case group
    when :test_1
      "Swift"
    when :test_2
      "Ruby"
    end
  end

end


# Call
UserSerializer.new().serialize(user) 
=> {id:..., name: ..., age:...}

UserSerializer.new(group: :full_info).serialize(user) 
=> {id:..., name: ..., age:..., full_name:..., address:...}

UserSerializer.new(group: :full_info_with_avatars).serialize(user) 
=> {id:..., name: ..., age:..., full_name:..., address:..., avatars:...}

UserSerializer.new(group: :posts).serialize(user) 
=> {id:..., name: ..., age:..., posts:...}

etc ...

```

maybe this feature will be ok for you ...