### PR TITLE
Fix typo: serailizer -> serializer

### DIFF
--- a/docs/associations.md
+++ b/docs/associations.md
@@ -5,7 +5,7 @@ A serializer can define it's own associations - both `has_many` and `has_one` to
 For example:
 
 ```ruby
-class PostSerializer < Panko::Serailizer
+class PostSerializer < Panko::Serializer
   attributes :title, :body
 
   has_one :author, serializer: AuthorSerializer
@@ -19,7 +19,7 @@ Panko can find the type of the serializer by looking at the realtionship name, s
 the serializer at the above example, we can -
 
 ```ruby
-class PostSerializer < Panko::Serailizer
+class PostSerializer < Panko::Serializer
   attributes :title, :body
 
   has_one :author

--- a/spec/panko/serializer_spec.rb
+++ b/spec/panko/serializer_spec.rb
@@ -78,7 +78,7 @@ describe Panko::Serializer do
                                                "something" => "#{foo.name} #{foo.address}")
     end
 
-    it "supports serailizer inheritance" do
+    it "supports serializer inheritance" do
       class BaseSerializer < Panko::Serializer
         attributes :name
       end


### PR DESCRIPTION
I was copying and pasting from the example code in the docs and got a runtime error. This patch fixes the the typo in three places.