### PR TITLE
[issue-47] Raise error if serializer is reused

### DIFF
--- a/lib/panko/serializer.rb
+++ b/lib/panko/serializer.rb
@@ -102,6 +102,7 @@ module Panko
 
       @serialization_context = SerializationContext.create(options)
       @descriptor = Panko::SerializationDescriptor.build(self.class, options, @serialization_context)
+      @used = false
     end
 
     def context
@@ -126,7 +127,9 @@ module Panko
     private
 
     def serialize_with_writer(object, writer)
+      raise ArgumentError.new("Panko::Serializer instances are single-use") if @used
       Panko.serialize_object(object, writer, @descriptor)
+      @used = true
       writer
     end
   end

--- a/spec/panko/array_serializer_spec.rb
+++ b/spec/panko/array_serializer_spec.rb
@@ -15,12 +15,12 @@ describe Panko::ArraySerializer do
 
   context "sanity" do
     it "serializers array of elements" do
-      array_serializer = Panko::ArraySerializer.new([], each_serializer: FooSerializer)
+      array_serializer_factory = -> { Panko::ArraySerializer.new([], each_serializer: FooSerializer) }
 
       foo1 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
       foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
 
-      expect(Foo.all).to serialized_as(array_serializer, [
+      expect(Foo.all).to serialized_as(array_serializer_factory, [
                                          { "name" => foo1.name, "address" => foo1.address },
                                          { "name" => foo2.name, "address" => foo2.address }
                                        ])
@@ -41,11 +41,11 @@ describe Panko::ArraySerializer do
 
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
 
-      array_serializer = Panko::ArraySerializer.new([],
+      array_serializer_factory = -> { Panko::ArraySerializer.new([],
                                                     each_serializer: TestSerializerWithMethodsSerializer,
-                                                    context: { value: 6 })
+                                                    context: { value: 6 }) }
 
-      expect(Foo.all).to serialized_as(array_serializer, [{ "name" => foo.name,
+      expect(Foo.all).to serialized_as(array_serializer_factory, [{ "name" => foo.name,
                                                             "address" => foo.address,
                                                             "something" => "#{foo.name} #{foo.address}",
                                                             "context_fetch" => 6 }])
@@ -54,24 +54,24 @@ describe Panko::ArraySerializer do
 
   context "filter" do
     it "only" do
-      array_serializer = Panko::ArraySerializer.new([], each_serializer: FooSerializer, only: [:name])
+      array_serializer_factory = -> { Panko::ArraySerializer.new([], each_serializer: FooSerializer, only: [:name]) }
 
       foo1 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
       foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
 
-      expect(Foo.all).to serialized_as(array_serializer, [
+      expect(Foo.all).to serialized_as(array_serializer_factory, [
                                          { "name" => foo1.name },
                                          { "name" => foo2.name }
                                        ])
     end
 
     it "except" do
-      array_serializer = Panko::ArraySerializer.new([], each_serializer: FooSerializer, except: [:name])
+      array_serializer_factory = -> { Panko::ArraySerializer.new([], each_serializer: FooSerializer, except: [:name]) }
 
       foo1 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
       foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word)
 
-      expect(Foo.all).to serialized_as(array_serializer, [
+      expect(Foo.all).to serialized_as(array_serializer_factory, [
                                          { "address" => foo1.address },
                                          { "address" => foo2.address }
                                        ])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,11 +34,17 @@ RSpec.configure do |config|
   end
 end
 
-RSpec::Matchers.define :serialized_as do |serializer, output|
-  match do |object|
-    expect(serializer.serialize(object)).to eq(output)
+RSpec::Matchers.define :serialized_as do |serializer_factory_or_class, output|
+  serializer_factory = if serializer_factory_or_class.respond_to?(:call)
+    serializer_factory_or_class
+  else
+    -> { serializer_factory_or_class.new }
+  end
 
-    json = Oj.load serializer.serialize_to_json(object)
+  match do |object|
+    expect(serializer_factory.().serialize(object)).to eq(output)
+
+    json = Oj.load serializer_factory.().serialize_to_json(object)
     expect(json).to eq(output)
   end
 
@@ -50,8 +56,8 @@ RSpec::Matchers.define :serialized_as do |serializer, output|
 
       Got:
 
-      Object: #{serializer.serialize(object)}
-      JSON: #{Oj.load(serializer.serialize_to_json(object))}
+      Object: #{serializer_factory.().serialize(object)}
+      JSON: #{Oj.load(serializer_factory.().serialize_to_json(object))}
     FAILURE
   end
 end


### PR DESCRIPTION
This causes `serialize` or `seriaize_to_json` to raise an `ArgumentError` if you try and serialize more than once with the same `Panko::Serializer` object.

Turned out to be a lot bigger than I expected as the `serialized_as` matcher actually uses the same serializer more than once as it uses both methods with the same object. I didn't know if would be a good idea to allow this case, as then you get in to object comparison issues?

I've updated `serialized_as` to accept either a serializer class name to build a simple serializer with no options, or a lambda, to build more complex serializer instances. This allows `serialized_as` to create new instances of the same serializer, as previously taking in an already created instance made this impossible.

fixes #47 
