### PR TITLE
[issue-48] Ability to serialize a hash object

### DIFF
--- a/ext/panko_serializer/attributes_writer/attributes_writer.c
+++ b/ext/panko_serializer/attributes_writer/attributes_writer.c
@@ -2,6 +2,7 @@
 
 static bool types_initialized = false;
 static VALUE ar_base_type = Qundef;
+static VALUE hash_type = Qundef;
 
 VALUE init_types(VALUE v) {
   if (types_initialized == true) {
@@ -13,6 +14,8 @@ VALUE init_types(VALUE v) {
   volatile VALUE ar_type =
       rb_const_get_at(rb_cObject, rb_intern("ActiveRecord"));
   ar_base_type = rb_const_get_at(ar_type, rb_intern("Base"));
+
+  hash_type = rb_const_get_at(rb_cObject, rb_intern("Hash"));
 
   return Qundef;
 }
@@ -28,6 +31,12 @@ AttributesWriter create_attributes_writer(VALUE object) {
         .object_type = ActiveRecord,
         .write_attributes = active_record_attributes_writer};
   }
+
+  if (rb_obj_is_kind_of(object, hash_type) == Qtrue) {
+    return (AttributesWriter){.object_type = Hash,
+                            .write_attributes = hash_attributes_writer};
+  }
+
   return (AttributesWriter){.object_type = Plain,
                             .write_attributes = plain_attributes_writer};
 

--- a/ext/panko_serializer/attributes_writer/attributes_writer.h
+++ b/ext/panko_serializer/attributes_writer/attributes_writer.h
@@ -5,8 +5,9 @@
 #include "active_record.h"
 #include "common.h"
 #include "plain.h"
+#include "hash.h"
 
-enum ObjectType { Unknown = 0, ActiveRecord = 1, Plain = 2 };
+enum ObjectType { Unknown = 0, ActiveRecord = 1, Plain = 2, Hash = 3 };
 
 typedef struct _AttributesWriter {
   enum ObjectType object_type;

--- a/ext/panko_serializer/attributes_writer/hash.c
+++ b/ext/panko_serializer/attributes_writer/hash.c
@@ -1,0 +1,14 @@
+#include "hash.h"
+
+void hash_attributes_writer(VALUE obj, VALUE attributes,
+                             EachAttributeFunc func, VALUE writer) {
+  long i;
+  for (i = 0; i < RARRAY_LEN(attributes); i++) {
+    volatile VALUE raw_attribute = RARRAY_AREF(attributes, i);
+    Attribute attribute = attribute_read(raw_attribute);
+
+    volatile VALUE value = rb_hash_aref(obj, attribute->name_str);
+
+    func(writer, attr_name_for_serialization(attribute), value);
+  }
+}

--- a/ext/panko_serializer/attributes_writer/hash.h
+++ b/ext/panko_serializer/attributes_writer/hash.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "common.h"
+#include "ruby.h"
+
+void hash_attributes_writer(VALUE obj,
+                             VALUE attributes,
+                             EachAttributeFunc func,
+                             VALUE writer);

--- a/spec/panko/serializer_spec.rb
+++ b/spec/panko/serializer_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 require "spec_helper"
 require "active_record/connection_adapters/postgresql_adapter"
 
@@ -40,6 +39,39 @@ describe Panko::Serializer do
       expect(foo).to serialized_as(FooSerializer,
                                    "name" => foo.name,
                                    "address" => foo.address)
+    end
+
+    it "hash (with string keys)" do
+      foo = {
+        "name" => Faker::Lorem.word,
+        "address" => Faker::Lorem.word
+      }
+
+      expect(foo).to serialized_as(FooSerializer,
+                                   "name" => foo["name"],
+                                   "address" => foo["address"])
+    end
+
+    it "HashWithIndifferentAccess (with symbol keys)" do
+      foo = ActiveSupport::HashWithIndifferentAccess.new(
+        name: Faker::Lorem.word,
+        address: Faker::Lorem.word
+      )
+
+      expect(foo).to serialized_as(FooSerializer,
+                                   "name" => foo["name"],
+                                   "address" => foo["address"])
+    end
+
+    it "HashWithIndifferentAccess (with string keys)" do
+      foo = ActiveSupport::HashWithIndifferentAccess.new(
+        "name" => Faker::Lorem.word,
+        "address" => Faker::Lorem.word
+      )
+
+      expect(foo).to serialized_as(FooSerializer,
+                                   "name" => foo["name"],
+                                   "address" => foo["address"])
     end
   end
 
@@ -167,7 +199,7 @@ describe Panko::Serializer do
       end
 
       context = { value: Faker::Lorem.word }
-      serializer_factory = -> { FooWithContextSerializer.new(context: context) } 
+      serializer_factory = -> { FooWithContextSerializer.new(context: context) }
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
 
       expect(foo).to serialized_as(serializer_factory,
@@ -197,7 +229,7 @@ describe Panko::Serializer do
 
     it "passes scope to attribute methods" do
       scope = 123
-      serializer_factory = -> { FooHolderWithScopeSerializer.new(scope: scope) } 
+      serializer_factory = -> { FooHolderWithScopeSerializer.new(scope: scope) }
 
       foo = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
       foo_holder = FooHolder.create(name: Faker::Lorem.word, foo: foo).reload


### PR DESCRIPTION
If a `Hash` is passed as object, it will attempt to find attributes using `Hash#[]`. 

`PankoSerializer` must at some point turn `attributes :blah` from a `Symbol` to a `String`, as it only works with `String` keys. I think this is good enough as it'd be hard to detect which to use, and might cause confusion.

I attempted to make it work with `ActiveSupport::HashWithIndifferentAccess` but was unable to get the hash lookup working in ext

```ruby
    it "hash (with indifferent access)" do
      foo = ActiveSupport::HashWithIndifferentAccess.new(
        "name" => Faker::Lorem.word,
        "address" => Faker::Lorem.word
      )

      expect(foo).to serialized_as(FooSerializer,
                                   "name" => foo[:name],
                                   "address" => foo[:address])
    end
```

```c
void hash_attributes_writer(VALUE obj, VALUE attributes,
                             EachAttributeFunc func, VALUE writer) {
  long i;
  for (i = 0; i < RARRAY_LEN(attributes); i++) {
    volatile VALUE raw_attribute = RARRAY_AREF(attributes, i);
    Attribute attribute = attribute_read(raw_attribute);
    volatile VALUE value = rb_funcall(obj, rb_intern("[]"), 1, attribute->name_id);

    func(writer, attr_name_for_serialization(attribute), value);
  }
}
```

I expect `rb_hash_lookup` is faster than `rb_funcall` with `[]` but that might bypass overridden `[]` method on `Hash` subclasses like `ActiveSupport::HashWithIndifferentAccess`. Either way, it works for a plain Hash but not for `ActiveSupport::HashWithIndifferentAccess` and I can't figure out why (my `ext` experience is limited)

Fixes #48 

