### PR TITLE
Json Columns: performance improvements

### DIFF
--- a/benchmarks/bm_panko_json.rb
+++ b/benchmarks/bm_panko_json.rb
@@ -12,6 +12,10 @@ class PostFastSerializer < Panko::Serializer
   attributes :id, :body, :title, :author_id, :created_at
 end
 
+class PostFastWithJsonSerializer < Panko::Serializer
+  attributes :id, :body, :title, :author_id, :created_at, :data
+end
+
 class PostFastWithMethodCallSerializer < Panko::Serializer
   attributes :id, :body, :title, :author_id, :method_call
 
@@ -31,7 +35,6 @@ class AuthorWithHasManyFastSerializer < Panko::Serializer
 
   has_many :posts, serializer: PostFastSerializer
 end
-
 
 def benchmark(prefix, serializer, options = {})
   data = Benchmark.data
@@ -54,6 +57,7 @@ def benchmark(prefix, serializer, options = {})
 end
 
 benchmark "Simple", PostFastSerializer
+benchmark "SimpleWithJson", PostFastWithJsonSerializer
 benchmark "HasOne", PostWithHasOneFastSerializer
 benchmark "SimpleWithMethodCall", PostFastWithMethodCallSerializer
 benchmark "Except", PostWithHasOneFastSerializer, except: [:title]

--- a/benchmarks/setup.rb
+++ b/benchmarks/setup.rb
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define do
     t.text :body
     t.string :title
     t.references :author
+    t.json :data
     t.timestamps(null: false)
   end
 end
@@ -47,7 +48,8 @@ Post.transaction do
     Post.create(
       body: "something about how password restrictions are evil, and less secure, and with the math to prove it.",
       title: "Your bank is does not know how to do security",
-      author: Author.create(name: "Preston Sego")
+      author: Author.create(name: "Preston Sego"),
+      data: { a: 1, b: 2, c: 3 }
     )
   end
 end

--- a/benchmarks/type_casts/bm_panko.rb
+++ b/benchmarks/type_casts/bm_panko.rb
@@ -59,10 +59,10 @@ if ENV["RAILS_VERSION"].start_with? "4.2"
 end
 
 if check_if_exists "ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Json"
-  panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Json, '{"a":1}', {a:1}
+  panko_type_convert ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Json, '{"a":1}', '{"a":1}'
 end
 if check_if_exists "ActiveRecord::Type::Json"
-  panko_type_convert ActiveRecord::Type::Json, '{"a":1}', {a:1}
+  panko_type_convert ActiveRecord::Type::Json, '{"a":1}', '{"a":1}'
 end
 db_panko_time
 utc_panko_time

--- a/ext/panko_serializer/attributes_writer/common.h
+++ b/ext/panko_serializer/attributes_writer/common.h
@@ -3,6 +3,6 @@
 #include "../serialization_descriptor/attribute.h"
 #include "ruby.h"
 
-typedef void (*EachAttributeFunc)(VALUE writer, VALUE name, VALUE value);
+typedef void (*EachAttributeFunc)(VALUE writer, VALUE name, VALUE value, VALUE isJson);
 
 VALUE attr_name_for_serialization(Attribute attribute);

--- a/ext/panko_serializer/attributes_writer/hash.c
+++ b/ext/panko_serializer/attributes_writer/hash.c
@@ -1,14 +1,12 @@
 #include "hash.h"
 
 void hash_attributes_writer(VALUE obj, VALUE attributes,
-                             EachAttributeFunc func, VALUE writer) {
+                             EachAttributeFunc write_value, VALUE writer) {
   long i;
   for (i = 0; i < RARRAY_LEN(attributes); i++) {
     volatile VALUE raw_attribute = RARRAY_AREF(attributes, i);
     Attribute attribute = attribute_read(raw_attribute);
 
-    volatile VALUE value = rb_hash_aref(obj, attribute->name_str);
-
-    func(writer, attr_name_for_serialization(attribute), value);
+    write_value(writer, attr_name_for_serialization(attribute), rb_hash_aref(obj, attribute->name_str), Qfalse);
   }
 }

--- a/ext/panko_serializer/attributes_writer/plain.c
+++ b/ext/panko_serializer/attributes_writer/plain.c
@@ -1,13 +1,12 @@
 #include "plain.h"
 
 void plain_attributes_writer(VALUE obj, VALUE attributes,
-                             EachAttributeFunc func, VALUE writer) {
+                             EachAttributeFunc write_value, VALUE writer) {
   long i;
   for (i = 0; i < RARRAY_LEN(attributes); i++) {
     volatile VALUE raw_attribute = RARRAY_AREF(attributes, i);
     Attribute attribute = attribute_read(raw_attribute);
-    volatile VALUE value = rb_funcall(obj, attribute->name_id, 0);
 
-    func(writer, attr_name_for_serialization(attribute), value);
+    write_value(writer, attr_name_for_serialization(attribute), rb_funcall(obj, attribute->name_id, 0), Qfalse);
   }
 }

--- a/ext/panko_serializer/attributes_writer/type_cast/type_cast.h
+++ b/ext/panko_serializer/attributes_writer/type_cast/type_cast.h
@@ -68,11 +68,10 @@ static struct _TypeCast type_casts[] = {
     {is_boolean_type, cast_boolean_type},
     {is_date_time_type, cast_date_time_type},
     {is_float_type, cast_float_type},
-    {is_json_type, cast_json_type},
 
     {NULL, NULL}};
 
-extern VALUE type_cast(VALUE type_metadata, VALUE value);
+extern VALUE type_cast(VALUE type_metadata, VALUE value, VALUE* isJson);
 void panko_init_type_cast(VALUE mPanko);
 
 // Introduced in ruby 2.4

--- a/lib/panko/object_writer.rb
+++ b/lib/panko/object_writer.rb
@@ -33,6 +33,14 @@ class Panko::ObjectWriter
     @values.last[key] = value.as_json
   end
 
+  def push_json(value, key = nil)
+    if value.is_a?(String)
+      value = Oj.load(value) rescue nil
+    end
+
+    push_value(value, key)
+  end
+
   def pop
     result = @values.pop
 

--- a/spec/panko/type_cast_spec.rb
+++ b/spec/panko/type_cast_spec.rb
@@ -85,8 +85,8 @@ describe "Type Casting" do
     it { expect(Panko._type_cast(type, "shnitzel")).to be_nil }
     it { expect(Panko._type_cast(type, nil)).to be_nil }
 
-    it { expect(Panko._type_cast(type, '{"a":1}')).to eq("a" => 1) }
-    it { expect(Panko._type_cast(type, "[6,12]")).to eq([6, 12]) }
+    it { expect(Panko._type_cast(type, '{"a":1}')).to eq('{"a":1}') }
+    it { expect(Panko._type_cast(type, "[6,12]")).to eq("[6,12]") }
 
     it { expect(Panko._type_cast(type, "a" => 1)).to eq("a" => 1) }
     it { expect(Panko._type_cast(type, [6, 12])).to eq([6, 12]) }
@@ -99,8 +99,8 @@ describe "Type Casting" do
     it { expect(Panko._type_cast(type, "shnitzel")).to be_nil }
     it { expect(Panko._type_cast(type, nil)).to be_nil }
 
-    it { expect(Panko._type_cast(type, '{"a":1}')).to eq("a" => 1) }
-    it { expect(Panko._type_cast(type, "[6,12]")).to eq([6, 12]) }
+    it { expect(Panko._type_cast(type, '{"a":1}')).to eq('{"a":1}') }
+    it { expect(Panko._type_cast(type, "[6,12]")).to eq("[6,12]") }
 
     it { expect(Panko._type_cast(type, "a" => 1)).to eq("a" => 1) }
     it { expect(Panko._type_cast(type, [6, 12])).to eq([6, 12]) }


### PR DESCRIPTION
Until this commit we took json strings out of db and did JSON.parse on
them.

This commit changes this to:
- Use `Oj.sc_parse` to validate that the string is valid JSON
- Use `Oj::StringWriter#push_json` to push the json string as is.

Benchmarks:

master:
```
{"label":"Panko_ActiveRecord_SimpleWithJson_Posts_2300","ips":"93.59","allocs":"29919/0"}
{"label":"Panko_ActiveRecord_SimpleWithJson_Posts_50","ips":"4,296.59","allocs":"669/0"}
```

this commit:
```
{"label":"Panko_ActiveRecord_SimpleWithJson_Posts_2300","ips":"146.93","allocs":"9219/0"}
{"label":"Panko_ActiveRecord_SimpleWithJson_Posts_50","ips":"6,650.14","allocs":"219/0"}
```

less allocations and faster!