### PR TITLE
ci: update all actions to utilize Node16 instead of Node12

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
       working_directory: 'docs/'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
@@ -26,7 +26,7 @@ jobs:
       run: npm install
 
     - name: Install SSH Client 🔑
-      uses: webfactory/ssh-agent@v0.4.1
+      uses: webfactory/ssh-agent@v0.6.0
       with:
         ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
         rails: ["6.1.0", "7.0.0"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:
@@ -25,7 +25,7 @@ jobs:
 
       - name: Gems Cache
         id: gem-cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.rails }}-gem


### PR DESCRIPTION
Due to EOL of Node12 on GitHub Actions, the following actions are to be updated:

- actions/checkout from v2 to v4
- actions/cache from v1 to v3
- webfactory/ssh-agent from v0.4.1 to v0.6.0

## Refs.

https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/