### PR TITLE
chore: Rails 7.1 support by default

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,16 +19,12 @@ jobs:
           sudo apt install -y libsqlite3-dev
 
       - name: Install gems
-        env:
-          RAILS_VERSION: "7.0"
         run: |
           gem install bundler
           bundle config set path 'vendor/bundle'
           bundle check || bundle install --jobs 4 --retry 3
 
       - name: Lint ruby
-        env:
-          RAILS_VERSION: "7.0"
         run: |
           bundle exec rake standard
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.0", "3.1", "3.2"]
-        rails: ["6.1.0", "7.0.0"]
+        rails: ["6.1.0", "7.0.0", "7.1.0"]
 
     steps:
       - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-raw_rails_version = ENV.fetch("RAILS_VERSION", "6.1.0")
+raw_rails_version = ENV.fetch("RAILS_VERSION", "7.1.0")
 rails_version = "~> #{raw_rails_version}"
 
 gem "activesupport", rails_version


### PR DESCRIPTION
- Previous update: #110

## Rails 7.1 was released on 2023-10-05

https://rubyonrails.org/2023/10/5/Rails-7-1-0-has-been-released