### PR TITLE
ci: add Ruby head (3.3-pre) to the test matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", head]
         rails: ["6.1.0", "7.0.0", "7.1.0"]
 
     steps:


### PR DESCRIPTION
Ruby 3.3 (GA) is coming in 2 months.

- https://www.ruby-lang.org/en/news/2023/09/14/ruby-3-3-0-preview2-released/ etc.