### PR TITLE
docs: clarify example in Nested Filters

### DIFF
--- a/docs/docs/associations.md
+++ b/docs/docs/associations.md
@@ -63,7 +63,7 @@ We can declare tailored serializer for this, or we can re-use the above defined 
 ```ruby
 posts = Post.all
 
-Panko::ArraySerializer.new(posts, only: {
+Panko::ArraySerializer.new(posts, each_serializer: PostSerializer, only: {
   instance: [:title, :body, :author, :comments],
   author: [:id],
   comments: [:id],


### PR DESCRIPTION
Executing the code from this example:

```
posts = Post.all

Panko::ArraySerializer.new(posts, only: {
  instance: [:title, :body, :author, :comments],
  author: [:id],
  comments: [:id],
})
```

raises an ArgumentError:

```
ArgumentError (
Please pass valid each_serializer to ArraySerializer, for example:
> Panko::ArraySerializer.new(posts, each_serializer: PostSerializer)
        ):
```

I have modified the code example to match the error's suggestion.
