### PR TITLE
Configure Dependabot for automatic GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
I have seen on PR #174 that you have manually updated the GitHub Actions versions of the CI of this project.

This is something that could be automated with Dependabot :)