### PR TITLE
Fix "double_heap" warning

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,5 +65,5 @@ end
 if GC.respond_to?(:verify_compaction_references)
   # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
   # move objects around, helping to find object movement bugs.
-  GC.verify_compaction_references(double_heap: true, toward: :empty)
+  GC.verify_compaction_references(expand_heap: true, toward: :empty)
 end


### PR DESCRIPTION
```
<internal:gc>:286: warning: double_heap is deprecated, please use expand_heap instead
```