### PR TITLE
Update invalid documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@
 
 Panko is a library which is inspired by ActiveModelSerializers 0.9 for serializing ActiveRecord/Ruby objects to JSON strings, fast.
 
-To achieve its [performance](https://panko.dev/docs/performance/):
+To achieve its [performance](https://panko.dev/performance/):
 
 * Oj - Panko relies on Oj since it's fast and allows for incremental serialization using `Oj::StringWriter`
 * Serialization Descriptor - Panko computes most of the metadata ahead of time, to save time later in serialization.
 * Type casting — Panko does type casting by itself, instead of relying on ActiveRecord.
 
-To dig deeper about the performance choices, read [Design Choices](https://panko.dev/docs/design-choices/).
+To dig deeper about the performance choices, read [Design Choices](https://panko.dev/design-choices/).
 
 
 Support
 -------
 
-- [Documentation](https://panko.dev/docs)
-- [Getting Started](https://panko.dev/docs/getting-started/)
+- [Documentation](https://panko.dev/)
+- [Getting Started](https://panko.dev/getting-started/)
 
 License
 -------


### PR DESCRIPTION
Hey, while researching Panko Serializer gem I have realized that documentation links in README are broken as they include `/docs/` in the URL, for example: https://panko.dev/docs/design-choices/:

![image](https://github.com/user-attachments/assets/bca05287-6d81-4d8d-ae17-1f32486f20bc)

This pull request updates all the documentation links in README to the working versions:
- https://panko.dev/performance/
- https://panko.dev/design-choices/
- https://panko.dev/
- https://panko.dev/getting-started/
