### PR TITLE
update performance link on introduction page

### DIFF
--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -6,7 +6,7 @@ slug: /
 ---
 Panko is a library which is inspired by ActiveModelSerializers 0.9 for serializing ActiveRecord/Ruby objects to JSON strings, fast.
 
-To achieve it's [performance](https://panko.dev/docs/performance/):
+To achieve it's [performance](https://panko.dev/performance/):
 
 -   Oj - Panko relies on Oj since it's fast and allow to serialize incrementally using `Oj::StringWriter`.
 -   Serialization Descriptor - Panko computes most of the metadata ahead of time, to save time later in serialization.


### PR DESCRIPTION
Hey, the performance link on the introduction page is broken

<img width="944" height="392" alt="Screenshot 2025-09-24 at 9 38 26 PM" src="https://github.com/user-attachments/assets/bb7e6523-63db-403e-acb1-41a418009922" />
