### PR TITLE
Switch gemspec to allow-list for included files

### DIFF
--- a/panko_serializer.gemspec
+++ b/panko_serializer.gemspec
@@ -23,9 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.1.0"
 
-  spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files = Dir["{ext,lib}/**/*", "LICENSE.txt", "README.md"] & `git ls-files -z`.split("\x0")
   spec.require_paths = ["lib"]
 
   spec.extensions << "ext/panko_serializer/extconf.rb"


### PR DESCRIPTION
Use Dir glob with git ls-files intersection instead of reject-list,
ensuring only ext/, lib/, LICENSE.txt, and README.md are packaged.

Closes #216
