### PR TITLE
Use typed data API

### DIFF
--- a/ext/panko_serializer/serialization_descriptor/association.c
+++ b/ext/panko_serializer/serialization_descriptor/association.c
@@ -32,11 +32,13 @@ void association_mark(Association data) {
 
 static VALUE association_new(int argc, VALUE* argv, VALUE self) {
   Association association;
+  VALUE obj;
 
   Check_Type(argv[0], T_SYMBOL);
   Check_Type(argv[1], T_STRING);
 
-  association = ALLOC(struct _Association);
+  obj = Data_Make_Struct(cAssociation, struct _Association,
+                         association_mark, association_free, association);
   association->name_sym = argv[0];
   association->name_str = argv[1];
   association->rb_descriptor = argv[2];
@@ -44,8 +46,7 @@ static VALUE association_new(int argc, VALUE* argv, VALUE self) {
   association->name_id = rb_intern_str(rb_sym2str(association->name_sym));
   association->descriptor = sd_read(association->rb_descriptor);
 
-  return Data_Wrap_Struct(cAssociation, association_mark, association_free,
-                          association);
+  return obj;
 }
 
 Association association_read(VALUE association) {

--- a/ext/panko_serializer/serialization_descriptor/association.c
+++ b/ext/panko_serializer/serialization_descriptor/association.c
@@ -20,7 +20,7 @@ static void association_free(void* ptr) {
   xfree(association);
 }
 
-static void association_mark(void *data) {
+static void association_mark(void* data) {
   Association association = data;
 
   rb_gc_mark(association->name_str);
@@ -32,14 +32,20 @@ static void association_mark(void *data) {
   }
 }
 
-static size_t association_memsize(const void *data) {
+static size_t association_memsize(const void* data) {
   return data ? sizeof(struct _Association) : 0;
 }
 
 static const rb_data_type_t association_data_type = {
-  "Panko::Association",
-  {association_mark, association_free, association_memsize,},
-  0, 0, 0,
+    "Panko::Association",
+    {
+        association_mark,
+        association_free,
+        association_memsize,
+    },
+    0,
+    0,
+    0,
 };
 
 static VALUE association_new(int argc, VALUE* argv, VALUE self) {

--- a/ext/panko_serializer/serialization_descriptor/association.c
+++ b/ext/panko_serializer/serialization_descriptor/association.c
@@ -20,15 +20,27 @@ static void association_free(void* ptr) {
   xfree(association);
 }
 
-void association_mark(Association data) {
-  rb_gc_mark(data->name_str);
-  rb_gc_mark(data->name_sym);
-  rb_gc_mark(data->rb_descriptor);
+static void association_mark(void *data) {
+  Association association = data;
 
-  if (data->descriptor != NULL) {
-    sd_mark(data->descriptor);
+  rb_gc_mark(association->name_str);
+  rb_gc_mark(association->name_sym);
+  rb_gc_mark(association->rb_descriptor);
+
+  if (association->descriptor != NULL) {
+    sd_mark(association->descriptor);
   }
 }
+
+static size_t association_memsize(const void *data) {
+  return data ? sizeof(struct _Association) : 0;
+}
+
+static const rb_data_type_t association_data_type = {
+  "Panko::Association",
+  {association_mark, association_free, association_memsize,},
+  0, 0, 0,
+};
 
 static VALUE association_new(int argc, VALUE* argv, VALUE self) {
   Association association;
@@ -37,8 +49,8 @@ static VALUE association_new(int argc, VALUE* argv, VALUE self) {
   Check_Type(argv[0], T_SYMBOL);
   Check_Type(argv[1], T_STRING);
 
-  obj = Data_Make_Struct(cAssociation, struct _Association,
-                         association_mark, association_free, association);
+  obj = TypedData_Make_Struct(cAssociation, struct _Association,
+                              &association_data_type, association);
   association->name_sym = argv[0];
   association->name_str = argv[1];
   association->rb_descriptor = argv[2];
@@ -50,26 +62,31 @@ static VALUE association_new(int argc, VALUE* argv, VALUE self) {
 }
 
 Association association_read(VALUE association) {
-  return (Association)DATA_PTR(association);
+  Association ptr;
+
+  TypedData_Get_Struct(association, struct _Association, &association_data_type,
+                       ptr);
+
+  return ptr;
 }
 
 VALUE association_name_sym_ref(VALUE self) {
-  Association association = (Association)DATA_PTR(self);
+  Association association = association_read(self);
   return association->name_sym;
 }
 
 VALUE association_name_str_ref(VALUE self) {
-  Association association = (Association)DATA_PTR(self);
+  Association association = association_read(self);
   return association->name_str;
 }
 
 VALUE association_descriptor_ref(VALUE self) {
-  Association association = (Association)DATA_PTR(self);
+  Association association = association_read(self);
   return association->rb_descriptor;
 }
 
 VALUE association_decriptor_aset(VALUE self, VALUE descriptor) {
-  Association association = (Association)DATA_PTR(self);
+  Association association = association_read(self);
 
   association->rb_descriptor = descriptor;
   association->descriptor = sd_read(descriptor);

--- a/ext/panko_serializer/serialization_descriptor/attribute.c
+++ b/ext/panko_serializer/serialization_descriptor/attribute.c
@@ -27,21 +27,22 @@ void attribute_mark(Attribute data) {
 
 static VALUE attribute_new(int argc, VALUE* argv, VALUE self) {
   Attribute attribute;
+  VALUE obj;
 
   Check_Type(argv[0], T_STRING);
   if (argv[1] != Qnil) {
     Check_Type(argv[1], T_STRING);
   }
 
-  attribute = ALLOC(struct _Attribute);
+  obj = Data_Make_Struct(cAttribute, struct _Attribute,
+                         attribute_mark, attribute_free, attribute);
   attribute->name_str = argv[0];
   attribute->name_id = rb_intern_str(attribute->name_str);
   attribute->alias_name = argv[1];
   attribute->type = Qnil;
   attribute->record_class = Qnil;
 
-  return Data_Wrap_Struct(cAttribute, attribute_mark, attribute_free,
-                          attribute);
+  return obj;
 }
 
 Attribute attribute_read(VALUE attribute) {

--- a/ext/panko_serializer/serialization_descriptor/attribute.c
+++ b/ext/panko_serializer/serialization_descriptor/attribute.c
@@ -18,7 +18,7 @@ static void attribute_free(void* ptr) {
   xfree(attribute);
 }
 
-static void attribute_mark(void *data) {
+static void attribute_mark(void* data) {
   Attribute attribute = data;
 
   rb_gc_mark(attribute->name_str);
@@ -27,14 +27,20 @@ static void attribute_mark(void *data) {
   rb_gc_mark(attribute->record_class);
 }
 
-static size_t attribute_memsize(const void *data) {
+static size_t attribute_memsize(const void* data) {
   return data ? sizeof(struct _Attribute) : 0;
 }
 
 static const rb_data_type_t attribute_data_type = {
-  "Panko::Attribute",
-  {attribute_mark, attribute_free, attribute_memsize,},
-  0, 0, 0,
+    "Panko::Attribute",
+    {
+        attribute_mark,
+        attribute_free,
+        attribute_memsize,
+    },
+    0,
+    0,
+    0,
 };
 
 static VALUE attribute_new(int argc, VALUE* argv, VALUE self) {

--- a/ext/panko_serializer/serialization_descriptor/attribute.c
+++ b/ext/panko_serializer/serialization_descriptor/attribute.c
@@ -18,12 +18,24 @@ static void attribute_free(void* ptr) {
   xfree(attribute);
 }
 
-void attribute_mark(Attribute data) {
-  rb_gc_mark(data->name_str);
-  rb_gc_mark(data->alias_name);
-  rb_gc_mark(data->type);
-  rb_gc_mark(data->record_class);
+static void attribute_mark(void *data) {
+  Attribute attribute = data;
+
+  rb_gc_mark(attribute->name_str);
+  rb_gc_mark(attribute->alias_name);
+  rb_gc_mark(attribute->type);
+  rb_gc_mark(attribute->record_class);
 }
+
+static size_t attribute_memsize(const void *data) {
+  return data ? sizeof(struct _Attribute) : 0;
+}
+
+static const rb_data_type_t attribute_data_type = {
+  "Panko::Attribute",
+  {attribute_mark, attribute_free, attribute_memsize,},
+  0, 0, 0,
+};
 
 static VALUE attribute_new(int argc, VALUE* argv, VALUE self) {
   Attribute attribute;
@@ -34,8 +46,8 @@ static VALUE attribute_new(int argc, VALUE* argv, VALUE self) {
     Check_Type(argv[1], T_STRING);
   }
 
-  obj = Data_Make_Struct(cAttribute, struct _Attribute,
-                         attribute_mark, attribute_free, attribute);
+  obj = TypedData_Make_Struct(cAttribute, struct _Attribute,
+                              &attribute_data_type, attribute);
   attribute->name_str = argv[0];
   attribute->name_id = rb_intern_str(attribute->name_str);
   attribute->alias_name = argv[1];
@@ -46,7 +58,11 @@ static VALUE attribute_new(int argc, VALUE* argv, VALUE self) {
 }
 
 Attribute attribute_read(VALUE attribute) {
-  return (Attribute)DATA_PTR(attribute);
+  Attribute ptr;
+
+  TypedData_Get_Struct(attribute, struct _Attribute, &attribute_data_type, ptr);
+
+  return ptr;
 }
 
 void attribute_try_invalidate(Attribute attribute, VALUE new_record_class) {
@@ -74,12 +90,12 @@ void attribute_try_invalidate(Attribute attribute, VALUE new_record_class) {
 }
 
 VALUE attribute_name_ref(VALUE self) {
-  Attribute attribute = (Attribute)DATA_PTR(self);
+  Attribute attribute = attribute_read(self);
   return attribute->name_str;
 }
 
 VALUE attribute_alias_name_ref(VALUE self) {
-  Attribute attribute = (Attribute)DATA_PTR(self);
+  Attribute attribute = attribute_read(self);
   return attribute->alias_name;
 }
 

--- a/ext/panko_serializer/serialization_descriptor/attribute.h
+++ b/ext/panko_serializer/serialization_descriptor/attribute.h
@@ -22,6 +22,6 @@ Attribute attribute_read(VALUE attribute);
 void attribute_try_invalidate(Attribute attribute, VALUE new_record_class);
 void panko_init_attribute(VALUE mPanko);
 
-#define PANKO_ATTRIBUTE_READ(attribute) (Attribute) DATA_PTR(attribute)
+#define PANKO_ATTRIBUTE_READ(attribute) attribute_read(attribute)
 
 #endif

--- a/ext/panko_serializer/serialization_descriptor/serialization_descriptor.c
+++ b/ext/panko_serializer/serialization_descriptor/serialization_descriptor.c
@@ -3,7 +3,9 @@
 static ID object_id;
 static ID sc_id;
 
-static void sd_free(SerializationDescriptor sd) {
+static void sd_free(void *data) {
+  SerializationDescriptor sd = data;
+
   if (!sd) {
     return;
   }
@@ -18,20 +20,32 @@ static void sd_free(SerializationDescriptor sd) {
   xfree(sd);
 }
 
-void sd_mark(SerializationDescriptor data) {
-  rb_gc_mark(data->serializer);
-  rb_gc_mark(data->serializer_type);
-  rb_gc_mark(data->attributes);
-  rb_gc_mark(data->method_fields);
-  rb_gc_mark(data->has_one_associations);
-  rb_gc_mark(data->has_many_associations);
-  rb_gc_mark(data->aliases);
+void sd_mark(void *data) {
+  SerializationDescriptor sd = data;
+
+  rb_gc_mark(sd->serializer);
+  rb_gc_mark(sd->serializer_type);
+  rb_gc_mark(sd->attributes);
+  rb_gc_mark(sd->method_fields);
+  rb_gc_mark(sd->has_one_associations);
+  rb_gc_mark(sd->has_many_associations);
+  rb_gc_mark(sd->aliases);
 }
+
+static size_t sd_memsize(const void *data) {
+  return data ? sizeof(struct _SerializationDescriptor) : 0;
+}
+
+static const rb_data_type_t sd_data_type = {
+  "Panko::SerializationDescriptor",
+  {sd_mark, sd_free, sd_memsize,},
+  0, 0, 0,
+};
 
 static VALUE sd_alloc(VALUE klass) {
   SerializationDescriptor sd;
-  VALUE obj = Data_Make_Struct(klass, struct _SerializationDescriptor,
-                               sd_mark, sd_free, sd);
+  VALUE obj = TypedData_Make_Struct(klass, struct _SerializationDescriptor,
+                                    &sd_data_type, sd);
 
   sd->serializer = Qnil;
   sd->serializer_type = Qnil;
@@ -47,7 +61,12 @@ static VALUE sd_alloc(VALUE klass) {
 }
 
 SerializationDescriptor sd_read(VALUE descriptor) {
-  return (SerializationDescriptor)DATA_PTR(descriptor);
+  SerializationDescriptor sd;
+
+  TypedData_Get_Struct(descriptor, struct _SerializationDescriptor,
+                       &sd_data_type, sd);
+
+  return sd;
 }
 
 void sd_set_writer(SerializationDescriptor sd, VALUE object) {
@@ -59,82 +78,82 @@ void sd_set_writer(SerializationDescriptor sd, VALUE object) {
 }
 
 VALUE sd_serializer_set(VALUE self, VALUE serializer) {
-  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  SerializationDescriptor sd = sd_read(self);
 
   sd->serializer = serializer;
   return Qnil;
 }
 
 VALUE sd_serializer_ref(VALUE self) {
-  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  SerializationDescriptor sd = sd_read(self);
 
   return sd->serializer;
 }
 
 VALUE sd_attributes_set(VALUE self, VALUE attributes) {
-  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  SerializationDescriptor sd = sd_read(self);
 
   sd->attributes = attributes;
   return Qnil;
 }
 
 VALUE sd_attributes_ref(VALUE self) {
-  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  SerializationDescriptor sd = sd_read(self);
   return sd->attributes;
 }
 
 VALUE sd_method_fields_set(VALUE self, VALUE method_fields) {
-  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  SerializationDescriptor sd = sd_read(self);
   sd->method_fields = method_fields;
   return Qnil;
 }
 
 VALUE sd_method_fields_ref(VALUE self) {
-  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  SerializationDescriptor sd = sd_read(self);
   return sd->method_fields;
 }
 
 VALUE sd_has_one_associations_set(VALUE self, VALUE has_one_associations) {
-  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  SerializationDescriptor sd = sd_read(self);
   sd->has_one_associations = has_one_associations;
   return Qnil;
 }
 
 VALUE sd_has_one_associations_ref(VALUE self) {
-  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  SerializationDescriptor sd = sd_read(self);
   return sd->has_one_associations;
 }
 
 VALUE sd_has_many_associations_set(VALUE self, VALUE has_many_associations) {
-  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  SerializationDescriptor sd = sd_read(self);
   sd->has_many_associations = has_many_associations;
   return Qnil;
 }
 
 VALUE sd_has_many_associations_ref(VALUE self) {
-  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  SerializationDescriptor sd = sd_read(self);
   return sd->has_many_associations;
 }
 
 VALUE sd_type_set(VALUE self, VALUE type) {
-  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  SerializationDescriptor sd = sd_read(self);
   sd->serializer_type = type;
   return Qnil;
 }
 
 VALUE sd_type_aref(VALUE self) {
-  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  SerializationDescriptor sd = sd_read(self);
   return sd->serializer_type;
 }
 
 VALUE sd_aliases_set(VALUE self, VALUE aliases) {
-  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  SerializationDescriptor sd = sd_read(self);
   sd->aliases = aliases;
   return Qnil;
 }
 
 VALUE sd_aliases_aref(VALUE self) {
-  SerializationDescriptor sd = (SerializationDescriptor)DATA_PTR(self);
+  SerializationDescriptor sd = sd_read(self);
   return sd->aliases;
 }
 

--- a/ext/panko_serializer/serialization_descriptor/serialization_descriptor.c
+++ b/ext/panko_serializer/serialization_descriptor/serialization_descriptor.c
@@ -3,7 +3,7 @@
 static ID object_id;
 static ID sc_id;
 
-static void sd_free(void *data) {
+static void sd_free(void* data) {
   SerializationDescriptor sd = data;
 
   if (!sd) {
@@ -20,7 +20,7 @@ static void sd_free(void *data) {
   xfree(sd);
 }
 
-void sd_mark(void *data) {
+void sd_mark(void* data) {
   SerializationDescriptor sd = data;
 
   rb_gc_mark(sd->serializer);
@@ -32,14 +32,20 @@ void sd_mark(void *data) {
   rb_gc_mark(sd->aliases);
 }
 
-static size_t sd_memsize(const void *data) {
+static size_t sd_memsize(const void* data) {
   return data ? sizeof(struct _SerializationDescriptor) : 0;
 }
 
 static const rb_data_type_t sd_data_type = {
-  "Panko::SerializationDescriptor",
-  {sd_mark, sd_free, sd_memsize,},
-  0, 0, 0,
+    "Panko::SerializationDescriptor",
+    {
+        sd_mark,
+        sd_free,
+        sd_memsize,
+    },
+    0,
+    0,
+    0,
 };
 
 static VALUE sd_alloc(VALUE klass) {

--- a/ext/panko_serializer/serialization_descriptor/serialization_descriptor.c
+++ b/ext/panko_serializer/serialization_descriptor/serialization_descriptor.c
@@ -29,7 +29,9 @@ void sd_mark(SerializationDescriptor data) {
 }
 
 static VALUE sd_alloc(VALUE klass) {
-  SerializationDescriptor sd = ALLOC(struct _SerializationDescriptor);
+  SerializationDescriptor sd;
+  VALUE obj = Data_Make_Struct(klass, struct _SerializationDescriptor,
+                               sd_mark, sd_free, sd);
 
   sd->serializer = Qnil;
   sd->serializer_type = Qnil;
@@ -41,7 +43,7 @@ static VALUE sd_alloc(VALUE klass) {
 
   sd->attributes_writer = create_empty_attributes_writer();
 
-  return Data_Wrap_Struct(klass, sd_mark, sd_free, sd);
+  return obj;
 }
 
 SerializationDescriptor sd_read(VALUE descriptor) {

--- a/ext/panko_serializer/serialization_descriptor/serialization_descriptor.h
+++ b/ext/panko_serializer/serialization_descriptor/serialization_descriptor.h
@@ -23,7 +23,7 @@ typedef struct _SerializationDescriptor {
 
 SerializationDescriptor sd_read(VALUE descriptor);
 
-void sd_mark(void *data);
+void sd_mark(void* data);
 
 void sd_set_writer(SerializationDescriptor sd, VALUE object);
 

--- a/ext/panko_serializer/serialization_descriptor/serialization_descriptor.h
+++ b/ext/panko_serializer/serialization_descriptor/serialization_descriptor.h
@@ -23,7 +23,7 @@ typedef struct _SerializationDescriptor {
 
 SerializationDescriptor sd_read(VALUE descriptor);
 
-void sd_mark(SerializationDescriptor data);
+void sd_mark(void *data);
 
 void sd_set_writer(SerializationDescriptor sd, VALUE object);
 


### PR DESCRIPTION
* Use Data_Make_Struct for parser allocation
  Allocate the parser with Data_Make_Struct so Ruby owns the memory as soon as the object is created.  This avoids leaking the malloc buffer if an exception raises between malloc and wrap.

* Use typed data for serialization descriptors
  Use TypedData_Make_Struct and TypedData_Get_Struct for SerializationDescriptor, Attribute, and Association so the extension no longer depends on old Data_* accessors.
